### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -4,6 +4,8 @@
 # documentation.
 
 name: Dart
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/alihassan143/htmltopdfwidgets/security/code-scanning/1](https://github.com/alihassan143/htmltopdfwidgets/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only needs to check out code and run tests, it only requires `contents: read` permission. The best way to do this is to add the following at the top level of the workflow (after the `name:` field and before `on:`), so it applies to all jobs in the workflow. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
