### PR TITLE
fix: Images not showing in MS Word (#90)

### DIFF
--- a/packages/docx_creator/CHANGELOG.md
+++ b/packages/docx_creator/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 1.2.4
+
+### Fixed
+- **Images Not Showing in MS Word**: Fixed critical issue where images in body, headers, and footers would render in LibreOffice but not in Microsoft Word (#90).
+  - Added required `wp:cNvGraphicFramePr` element (with `a:graphicFrameLocks noChangeAspect="1"`) to both inline (`wp:inline`) and floating (`wp:anchor`) image drawings, as mandated by the OOXML specification.
+  - Added missing `xmlns:a` (DrawingML) and `xmlns:pic` (Picture) namespace declarations to header and footer XML files, which are separate documents from `document.xml` and require their own namespace bindings.
+
+### Added
+- **MS Word Compatibility Tests**: Added 8 comprehensive tests (`image_ms_word_compat_test.dart`) that generate DOCX files, extract the ZIP, and verify XML structure for MS Word compatibility — including `wp:cNvGraphicFramePr` presence, namespace declarations, `.rels` files, media inclusion, and content type registration.
+
+---
+
 ## 1.2.3
 
 ### Fixed

--- a/packages/docx_creator/lib/src/ast/docx_image.dart
+++ b/packages/docx_creator/lib/src/ast/docx_image.dart
@@ -178,6 +178,7 @@ class DocxInlineImage extends DocxInline {
           },
         );
         _buildDocPr(builder);
+        _buildCNvGraphicFramePr(builder);
         _buildGraphic(builder, cx, cy);
       },
     );
@@ -259,6 +260,7 @@ class DocxInlineImage extends DocxInline {
 
         _buildTextWrap(builder);
         _buildDocPr(builder);
+        _buildCNvGraphicFramePr(builder);
         _buildGraphic(builder, cx, cy);
       },
     );
@@ -301,6 +303,19 @@ class DocxInlineImage extends DocxInline {
         if (altText != null) {
           builder.attribute('descr', altText!);
         }
+      },
+    );
+  }
+
+  void _buildCNvGraphicFramePr(XmlBuilder builder) {
+    builder.element(
+      'wp:cNvGraphicFramePr',
+      nest: () {
+        builder.element('a:graphicFrameLocks', nest: () {
+          builder.attribute('xmlns:a',
+              'http://schemas.openxmlformats.org/drawingml/2006/main');
+          builder.attribute('noChangeAspect', '1');
+        });
       },
     );
   }

--- a/packages/docx_creator/lib/src/exporters/docx/generators/header_footer_generator.dart
+++ b/packages/docx_creator/lib/src/exporters/docx/generators/header_footer_generator.dart
@@ -20,8 +20,8 @@ class DocxHeaderFooterGenerator {
             'http://schemas.openxmlformats.org/officeDocument/2006/relationships');
         builder.attribute('xmlns:wp',
             'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing');
-        builder.attribute('xmlns:a',
-            'http://schemas.openxmlformats.org/drawingml/2006/main');
+        builder.attribute(
+            'xmlns:a', 'http://schemas.openxmlformats.org/drawingml/2006/main');
         builder.attribute('xmlns:pic',
             'http://schemas.openxmlformats.org/drawingml/2006/picture');
         (state.doc.section!.header as DocxNode).buildXml(builder);
@@ -48,8 +48,8 @@ class DocxHeaderFooterGenerator {
             'http://schemas.openxmlformats.org/officeDocument/2006/relationships');
         builder.attribute('xmlns:wp',
             'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing');
-        builder.attribute('xmlns:a',
-            'http://schemas.openxmlformats.org/drawingml/2006/main');
+        builder.attribute(
+            'xmlns:a', 'http://schemas.openxmlformats.org/drawingml/2006/main');
         builder.attribute('xmlns:pic',
             'http://schemas.openxmlformats.org/drawingml/2006/picture');
         (state.doc.section!.footer as DocxNode).buildXml(builder);

--- a/packages/docx_creator/lib/src/exporters/docx/generators/header_footer_generator.dart
+++ b/packages/docx_creator/lib/src/exporters/docx/generators/header_footer_generator.dart
@@ -20,6 +20,10 @@ class DocxHeaderFooterGenerator {
             'http://schemas.openxmlformats.org/officeDocument/2006/relationships');
         builder.attribute('xmlns:wp',
             'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing');
+        builder.attribute('xmlns:a',
+            'http://schemas.openxmlformats.org/drawingml/2006/main');
+        builder.attribute('xmlns:pic',
+            'http://schemas.openxmlformats.org/drawingml/2006/picture');
         (state.doc.section!.header as DocxNode).buildXml(builder);
       },
     );
@@ -44,6 +48,10 @@ class DocxHeaderFooterGenerator {
             'http://schemas.openxmlformats.org/officeDocument/2006/relationships');
         builder.attribute('xmlns:wp',
             'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing');
+        builder.attribute('xmlns:a',
+            'http://schemas.openxmlformats.org/drawingml/2006/main');
+        builder.attribute('xmlns:pic',
+            'http://schemas.openxmlformats.org/drawingml/2006/picture');
         (state.doc.section!.footer as DocxNode).buildXml(builder);
       },
     );

--- a/packages/docx_creator/pubspec.yaml
+++ b/packages/docx_creator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: docx_creator
 description: A developer-first Dart package for creating professional DOCX documents with fluent API, Markdown/HTML parsing, and comprehensive formatting.
-version: 1.2.3
+version: 1.2.4
 repository: https://github.com/alihassan143/flutter-packages
 homepage: https://github.com/alihassan143/flutter-packages/tree/main/packages/docx_creator
 topics:

--- a/packages/docx_creator/test/image_ms_word_compat_test.dart
+++ b/packages/docx_creator/test/image_ms_word_compat_test.dart
@@ -1,0 +1,458 @@
+import 'dart:convert';
+// import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:archive/archive.dart';
+import 'package:docx_creator/docx_creator.dart';
+import 'package:test/test.dart';
+import 'package:xml/xml.dart';
+
+/// Creates a minimal 1x1 PNG image for testing.
+Uint8List _createTestPng() {
+  // Minimal valid 1x1 red PNG
+  const pngBase64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4'
+      'nGP4z8BQDwAEgAF/pooBPQAAAABJRU5ErkJggg==';
+  return base64Decode(pngBase64);
+}
+
+void main() {
+  group('MS Word Image Compatibility (Issue #90)', () {
+    late Uint8List testPng;
+
+    setUp(() {
+      testPng = _createTestPng();
+    });
+
+    // ======================================================================
+    // Core structural tests: verify wp:cNvGraphicFramePr is present
+    // ======================================================================
+
+    test('Body inline image has wp:cNvGraphicFramePr element', () async {
+      final doc = DocxDocumentBuilder()
+          .p('Before image')
+          .image(DocxImage(
+            bytes: testPng,
+            extension: 'png',
+            width: 100,
+            height: 100,
+          ))
+          .p('After image')
+          .build();
+
+      final exporter = DocxExporter();
+      final bytes = await exporter.exportToBytes(doc);
+      final archive = ZipDecoder().decodeBytes(bytes);
+
+      final documentFile =
+          archive.files.firstWhere((f) => f.name == 'word/document.xml');
+      final documentXml = utf8.decode(documentFile.content);
+
+      // Must contain the drawing structure
+      expect(documentXml, contains('w:drawing'));
+      expect(documentXml, contains('wp:inline'));
+
+      // Parse and verify cNvGraphicFramePr exists as child of wp:inline
+      final xmlDoc = XmlDocument.parse(documentXml);
+      final inlines = xmlDoc.findAllElements('wp:inline');
+      expect(inlines, isNotEmpty, reason: 'Should have wp:inline elements');
+
+      for (final inline in inlines) {
+        final cNvGfp = inline.findElements('wp:cNvGraphicFramePr');
+        expect(cNvGfp, isNotEmpty,
+            reason: 'wp:inline must contain wp:cNvGraphicFramePr for MS Word');
+
+        // Verify graphicFrameLocks with noChangeAspect
+        final locks = cNvGfp.first.findElements('a:graphicFrameLocks');
+        expect(locks, isNotEmpty,
+            reason: 'cNvGraphicFramePr must contain a:graphicFrameLocks');
+        expect(locks.first.getAttribute('noChangeAspect'), equals('1'));
+      }
+    });
+
+    test('Floating image has wp:cNvGraphicFramePr element', () async {
+      final doc = DocxDocumentBuilder()
+          .p('Before floating image')
+          .add(DocxParagraph(children: [
+            DocxInlineImage(
+              bytes: testPng,
+              extension: 'png',
+              width: 100,
+              height: 100,
+              positionMode: DocxDrawingPosition.floating,
+              textWrap: DocxTextWrap.square,
+            ),
+          ]))
+          .build();
+
+      final exporter = DocxExporter();
+      final bytes = await exporter.exportToBytes(doc);
+      final archive = ZipDecoder().decodeBytes(bytes);
+
+      final documentFile =
+          archive.files.firstWhere((f) => f.name == 'word/document.xml');
+      final documentXml = utf8.decode(documentFile.content);
+
+      final xmlDoc = XmlDocument.parse(documentXml);
+      final anchors = xmlDoc.findAllElements('wp:anchor');
+      expect(anchors, isNotEmpty, reason: 'Should have wp:anchor elements');
+
+      for (final anchor in anchors) {
+        final cNvGfp = anchor.findElements('wp:cNvGraphicFramePr');
+        expect(cNvGfp, isNotEmpty,
+            reason: 'wp:anchor must contain wp:cNvGraphicFramePr for MS Word');
+      }
+    });
+
+    // ======================================================================
+    // Header/Footer namespace and image rendering tests
+    // ======================================================================
+
+    test('Header XML has a: and pic: namespace declarations', () async {
+      final doc = DocxDocumentBuilder()
+          .section(
+            header: DocxHeader(children: [
+              DocxParagraph(children: [DocxText('Header Text')]),
+            ]),
+          )
+          .p('Body content')
+          .build();
+
+      final exporter = DocxExporter();
+      final bytes = await exporter.exportToBytes(doc);
+      final archive = ZipDecoder().decodeBytes(bytes);
+
+      final headerFile =
+          archive.files.firstWhere((f) => f.name == 'word/header1.xml');
+      final headerXml = utf8.decode(headerFile.content);
+
+      final xmlDoc = XmlDocument.parse(headerXml);
+      final hdr = xmlDoc.rootElement;
+
+      expect(hdr.getAttribute('xmlns:a'), isNotNull,
+          reason: 'Header must declare xmlns:a namespace');
+      expect(hdr.getAttribute('xmlns:pic'), isNotNull,
+          reason: 'Header must declare xmlns:pic namespace');
+      expect(hdr.getAttribute('xmlns:a'),
+          equals('http://schemas.openxmlformats.org/drawingml/2006/main'));
+      expect(hdr.getAttribute('xmlns:pic'),
+          equals('http://schemas.openxmlformats.org/drawingml/2006/picture'));
+    });
+
+    test('Footer XML has a: and pic: namespace declarations', () async {
+      final doc = DocxDocumentBuilder()
+          .section(
+            footer: DocxFooter(children: [
+              DocxParagraph(children: [DocxText('Footer Text')]),
+            ]),
+          )
+          .p('Body content')
+          .build();
+
+      final exporter = DocxExporter();
+      final bytes = await exporter.exportToBytes(doc);
+      final archive = ZipDecoder().decodeBytes(bytes);
+
+      final footerFile =
+          archive.files.firstWhere((f) => f.name == 'word/footer1.xml');
+      final footerXml = utf8.decode(footerFile.content);
+
+      final xmlDoc = XmlDocument.parse(footerXml);
+      final ftr = xmlDoc.rootElement;
+
+      expect(ftr.getAttribute('xmlns:a'), isNotNull,
+          reason: 'Footer must declare xmlns:a namespace');
+      expect(ftr.getAttribute('xmlns:pic'), isNotNull,
+          reason: 'Footer must declare xmlns:pic namespace');
+    });
+
+    test('Footer with image generates correct XML and relationships', () async {
+      final doc = DocxDocumentBuilder()
+          .section(
+            footer: DocxFooter(children: [
+              DocxImage(
+                bytes: testPng,
+                extension: 'png',
+                width: 80,
+                height: 40,
+              ),
+            ]),
+          )
+          .p('Body content')
+          .build();
+
+      final exporter = DocxExporter();
+      final bytes = await exporter.exportToBytes(doc);
+      final archive = ZipDecoder().decodeBytes(bytes);
+
+      // 1. footer1.xml must exist
+      final footerFile =
+          archive.files.firstWhere((f) => f.name == 'word/footer1.xml');
+      final footerXml = utf8.decode(footerFile.content);
+      expect(footerXml, contains('w:drawing'),
+          reason: 'Footer must contain w:drawing for image');
+      expect(footerXml, contains('wp:inline'),
+          reason: 'Footer image must use wp:inline');
+      expect(footerXml, contains('wp:cNvGraphicFramePr'),
+          reason: 'Footer image must have cNvGraphicFramePr for MS Word');
+      expect(footerXml, contains('pic:pic'),
+          reason: 'Footer must contain pic:pic element');
+      expect(footerXml, contains('r:embed'),
+          reason: 'Footer image must have r:embed relationship');
+
+      // 2. footer1.xml.rels must exist with image relationship
+      final footerRelsFile = archive.files
+          .firstWhere((f) => f.name == 'word/_rels/footer1.xml.rels');
+      final footerRelsXml = utf8.decode(footerRelsFile.content);
+      expect(footerRelsXml, contains('Relationship'),
+          reason: 'Footer rels must have Relationship entries');
+      expect(footerRelsXml, contains('image'),
+          reason: 'Footer rels must reference image type');
+      expect(footerRelsXml, contains('media/'),
+          reason: 'Footer rels must point to media path');
+
+      // 3. Image file must exist in word/media/
+      final imageFiles = archive.files
+          .where((f) => f.name.startsWith('word/media/image'))
+          .toList();
+      expect(imageFiles, isNotEmpty,
+          reason: 'Image file must exist in word/media/');
+    });
+
+    test('Header with image generates correct XML and relationships', () async {
+      final doc = DocxDocumentBuilder()
+          .section(
+            header: DocxHeader(children: [
+              DocxImage(
+                bytes: testPng,
+                extension: 'png',
+                width: 80,
+                height: 40,
+              ),
+            ]),
+          )
+          .p('Body content')
+          .build();
+
+      final exporter = DocxExporter();
+      final bytes = await exporter.exportToBytes(doc);
+      final archive = ZipDecoder().decodeBytes(bytes);
+
+      // header1.xml must contain drawing with cNvGraphicFramePr
+      final headerFile =
+          archive.files.firstWhere((f) => f.name == 'word/header1.xml');
+      final headerXml = utf8.decode(headerFile.content);
+      expect(headerXml, contains('w:drawing'));
+      expect(headerXml, contains('wp:cNvGraphicFramePr'));
+      expect(headerXml, contains('pic:pic'));
+
+      // header1.xml.rels must exist
+      final headerRelsFile = archive.files
+          .firstWhere((f) => f.name == 'word/_rels/header1.xml.rels');
+      final headerRelsXml = utf8.decode(headerRelsFile.content);
+      expect(headerRelsXml, contains('image'));
+    });
+
+    // ======================================================================
+    // Combined test: body + header + footer images
+    // ======================================================================
+
+    test(
+        'Full document with images in body, header, and footer '
+        'produces MS Word-compatible DOCX', () async {
+      final doc = DocxDocumentBuilder()
+          .section(
+            header: DocxHeader(children: [
+              DocxImage(
+                bytes: testPng,
+                extension: 'png',
+                width: 60,
+                height: 30,
+              ),
+            ]),
+            footer: DocxFooter(children: [
+              DocxImage(
+                bytes: testPng,
+                extension: 'png',
+                width: 60,
+                height: 30,
+              ),
+            ]),
+          )
+          .p('Document with images everywhere')
+          .image(DocxImage(
+            bytes: testPng,
+            extension: 'png',
+            width: 200,
+            height: 150,
+          ))
+          .p('End of body')
+          .build();
+
+      final exporter = DocxExporter();
+      final bytes = await exporter.exportToBytes(doc);
+      final archive = ZipDecoder().decodeBytes(bytes);
+
+      // --- document.xml verification ---
+      final docFile =
+          archive.files.firstWhere((f) => f.name == 'word/document.xml');
+      final docXml = utf8.decode(docFile.content);
+      final docXmlDoc = XmlDocument.parse(docXml);
+
+      // Body image must have cNvGraphicFramePr
+      final bodyInlines = docXmlDoc.findAllElements('wp:inline');
+      expect(bodyInlines, isNotEmpty);
+      for (final inline in bodyInlines) {
+        expect(inline.findElements('wp:cNvGraphicFramePr'), isNotEmpty,
+            reason: 'Body image missing cNvGraphicFramePr');
+      }
+
+      // --- header1.xml verification ---
+      final headerFile =
+          archive.files.firstWhere((f) => f.name == 'word/header1.xml');
+      final headerXml = utf8.decode(headerFile.content);
+      final headerXmlDoc = XmlDocument.parse(headerXml);
+
+      // Header namespaces
+      final hdr = headerXmlDoc.rootElement;
+      expect(hdr.getAttribute('xmlns:a'), isNotNull,
+          reason: 'Header missing xmlns:a');
+      expect(hdr.getAttribute('xmlns:pic'), isNotNull,
+          reason: 'Header missing xmlns:pic');
+
+      // Header image structure
+      final headerInlines = headerXmlDoc.findAllElements('wp:inline');
+      expect(headerInlines, isNotEmpty);
+      for (final inline in headerInlines) {
+        expect(inline.findElements('wp:cNvGraphicFramePr'), isNotEmpty,
+            reason: 'Header image missing cNvGraphicFramePr');
+      }
+
+      // --- footer1.xml verification ---
+      final footerFile =
+          archive.files.firstWhere((f) => f.name == 'word/footer1.xml');
+      final footerXml = utf8.decode(footerFile.content);
+      final footerXmlDoc = XmlDocument.parse(footerXml);
+
+      // Footer namespaces
+      final ftr = footerXmlDoc.rootElement;
+      expect(ftr.getAttribute('xmlns:a'), isNotNull,
+          reason: 'Footer missing xmlns:a');
+      expect(ftr.getAttribute('xmlns:pic'), isNotNull,
+          reason: 'Footer missing xmlns:pic');
+
+      // Footer image structure
+      final footerInlines = footerXmlDoc.findAllElements('wp:inline');
+      expect(footerInlines, isNotEmpty);
+      for (final inline in footerInlines) {
+        expect(inline.findElements('wp:cNvGraphicFramePr'), isNotEmpty,
+            reason: 'Footer image missing cNvGraphicFramePr');
+      }
+
+      // --- Relationships verification ---
+      final docRels = archive.files
+          .firstWhere((f) => f.name == 'word/_rels/document.xml.rels');
+      final docRelsXml = utf8.decode(docRels.content);
+      expect(docRelsXml, contains('image'),
+          reason: 'document.xml.rels must have body image rel');
+
+      final headerRels = archive.files
+          .firstWhere((f) => f.name == 'word/_rels/header1.xml.rels');
+      final headerRelsXml = utf8.decode(headerRels.content);
+      expect(headerRelsXml, contains('image'),
+          reason: 'header1.xml.rels must have image rel');
+
+      final footerRels = archive.files
+          .firstWhere((f) => f.name == 'word/_rels/footer1.xml.rels');
+      final footerRelsXml = utf8.decode(footerRels.content);
+      expect(footerRelsXml, contains('image'),
+          reason: 'footer1.xml.rels must have image rel');
+
+      // --- Media files ---
+      final mediaFiles = archive.files
+          .where((f) => f.name.startsWith('word/media/image'))
+          .toList();
+      // Should have images for body + header + footer
+      expect(mediaFiles.length, greaterThanOrEqualTo(1),
+          reason: 'Archive must contain image media files');
+
+      // --- Content Types ---
+      final contentTypes =
+          archive.files.firstWhere((f) => f.name == '[Content_Types].xml');
+      final ctXml = utf8.decode(contentTypes.content);
+      expect(ctXml, contains('image/png'),
+          reason: 'Content types must declare image/png');
+      expect(ctXml, contains('header'),
+          reason: 'Content types must declare header part');
+      expect(ctXml, contains('footer'),
+          reason: 'Content types must declare footer part');
+    });
+
+    // ======================================================================
+    // DOCX file generation test — writes to disk for manual Word testing
+    // ======================================================================
+
+    test('Generates DOCX file for manual MS Word verification', () async {
+      // final image = await DocxBackgroundImage.fromUrl(
+      //     "https://images.unsplash.com/photo-1624555130581-1d9cca783bc0?q=80&w=1742&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D");
+
+      final doc = DocxDocumentBuilder()
+          .section(
+            header: DocxHeader(children: [
+              DocxParagraph(align: DocxAlign.left, children: [
+                DocxInlineImage(
+                  bytes: testPng,
+                  extension: 'png',
+                  width: 40,
+                  height: 40,
+                  altText: 'Header logo',
+                ),
+                DocxText(' Header with Image', fontWeight: DocxFontWeight.bold),
+              ]),
+            ]),
+            footer: DocxFooter(children: [
+              DocxParagraph(align: DocxAlign.center, children: [
+                DocxInlineImage(
+                  bytes: testPng,
+                  extension: 'png',
+                  width: 30,
+                  height: 30,
+                  altText: 'Footer icon',
+                ),
+              ]),
+              DocxParagraph(align: DocxAlign.center, children: [
+                DocxText('Page '),
+                DocxPageNumber(),
+                DocxText(' of '),
+                DocxPageCount(),
+              ]),
+            ]),
+          )
+          .h1('MS Word Compatibility Test')
+          .p('This document tests that images render correctly in MS Word.')
+          .p('Below is an inline image in the body:')
+          .image(DocxImage(
+            bytes: testPng,
+            extension: 'png',
+            width: 100,
+            height: 100,
+          ))
+          .p('The header and footer also contain images.')
+          .p('If you can see images in the header, footer, and body — the fix works!')
+          .build();
+
+      final exporter = DocxExporter();
+      final bytes = await exporter.exportToBytes(doc);
+
+      // Basic validity — can decode as ZIP
+      expect(bytes.length, greaterThan(0));
+      final archive = ZipDecoder().decodeBytes(bytes);
+      expect(archive.files.any((f) => f.name == 'word/document.xml'), true);
+      expect(archive.files.any((f) => f.name == 'word/header1.xml'), true);
+      expect(archive.files.any((f) => f.name == 'word/footer1.xml'), true);
+
+      // Uncomment below to write to disk for manual Word testing:
+      // // import 'dart:io';
+      // await File('test_output_ms_word_compat.docx').writeAsBytes(bytes);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Fixes #90 — Images added to DOCX documents (body, headers, footers) render in LibreOffice but **not in Microsoft Word**.

## Root Cause

Two issues in the generated XML:

### 1. Missing `wp:cNvGraphicFramePr` element
The OOXML spec requires a `wp:cNvGraphicFramePr` element (containing `a:graphicFrameLocks noChangeAspect="1"`) between `wp:docPr` and `a:graphic` in both `wp:inline` and `wp:anchor` drawing containers. Without it, MS Word silently skips rendering the image.

### 2. Missing namespace declarations in header/footer XML
Header and footer XML files are separate documents from `document.xml`. They need their own `xmlns:a` and `xmlns:pic` namespace declarations. Without them, MS Word rejects the image markup.

## Changes

| File | Change |
|------|--------|
| `lib/src/ast/docx_image.dart` | Added `_buildCNvGraphicFramePr()` helper; called in `_buildInline()` and `_buildAnchor()` |
| `lib/src/exporters/docx/generators/header_footer_generator.dart` | Added `xmlns:a` and `xmlns:pic` to `createHeader()` and `createFooter()` |
| `test/image_ms_word_compat_test.dart` | **New** — 8 tests verifying XML structure for MS Word compatibility |
| `pubspec.yaml` | Version bump to 1.2.4 |
| `CHANGELOG.md` | Added 1.2.4 entry |

## Tests

- **8 new tests** — all passing ✅
- **268 total tests** — 0 regressions ✅

Tests verify:
- `wp:cNvGraphicFramePr` present in inline and anchor images
- `xmlns:a` and `xmlns:pic` declared in header/footer XML
- Image relationships (`.rels` files) correct for header/footer
- Image media files present in archive
- Content types correctly registered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed DOCX image rendering for MS Word compatibility with proper XML structure for inline and floating images.
  * Fixed headers and footers containing images by adding required XML namespace declarations.

* **Tests**
  * Added comprehensive MS Word image compatibility test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->