### PR TITLE
Fix DOCX footer image rendering

### DIFF
--- a/packages/docx_creator/CHANGELOG.md
+++ b/packages/docx_creator/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 1.2.5
+
+### Fixed
+- **Standardized Footer/Header Image Rendering**: Fixed a critical issue where images in footers and headers were invisible in Microsoft Word due to missing DrawingML attributes and namespace discrepancies.
+  - Added mandatory `distT`, `distB`, `distL`, and `distR` attributes to `wp:inline`.
+  - Added `wp:effectExtent` element for proper boundary calculation.
+  - Synchronized `xmlns:mc`, `xmlns:w14`, and `xmlns:wp14` namespaces across all header and footer generators.
+- **Table-based Footer Layout**: Added `DocxFooter.imageAndText` factory for easier creation of professional footer layouts with images and text.
+
+### Added
+- **Global Image Rendering Tests**: Added `test/footer_global_fix_test.dart` to verify OOXML compliance of image generation without workarounds.
+
+---
+
 ## 1.2.4
 
 ### Fixed

--- a/packages/docx_creator/lib/src/ast/docx_image.dart
+++ b/packages/docx_creator/lib/src/ast/docx_image.dart
@@ -170,6 +170,11 @@ class DocxInlineImage extends DocxInline {
     builder.element(
       'wp:inline',
       nest: () {
+        builder.attribute('distT', distT.toString());
+        builder.attribute('distB', distB.toString());
+        builder.attribute('distL', distL.toString());
+        builder.attribute('distR', distR.toString());
+
         builder.element(
           'wp:extent',
           nest: () {
@@ -177,6 +182,17 @@ class DocxInlineImage extends DocxInline {
             builder.attribute('cy', cy);
           },
         );
+
+        builder.element(
+          'wp:effectExtent',
+          nest: () {
+            builder.attribute('l', effectExtentL.toString());
+            builder.attribute('t', effectExtentT.toString());
+            builder.attribute('r', effectExtentR.toString());
+            builder.attribute('b', effectExtentB.toString());
+          },
+        );
+
         _buildDocPr(builder);
         _buildCNvGraphicFramePr(builder);
         _buildGraphic(builder, cx, cy);

--- a/packages/docx_creator/lib/src/ast/docx_section.dart
+++ b/packages/docx_creator/lib/src/ast/docx_section.dart
@@ -1,11 +1,15 @@
+import 'dart:typed_data';
+
 import 'package:xml/xml.dart';
 
 import '../core/defaults.dart';
 import '../core/enums.dart';
 import 'docx_background_image.dart';
 import 'docx_block.dart';
+import 'docx_image.dart';
 import 'docx_inline.dart';
 import 'docx_node.dart';
+import 'docx_table.dart';
 
 /// Customizable heading style.
 ///
@@ -379,6 +383,68 @@ class DocxFooter extends DocxSection {
             DocxPageNumber(),
             DocxText(' of '),
             DocxPageCount(),
+          ],
+        ),
+      ],
+    );
+  }
+
+  /// Footer with an image on the left and text on the right using an invisible table.
+  factory DocxFooter.imageAndText({
+    required Uint8List imageBytes,
+    required String imageExtension,
+    required String text,
+    double imageWidth = 40,
+    double imageHeight = 40,
+    DocxAlign textAlign = DocxAlign.right,
+  }) {
+    const borderNone = DocxBorderSide(
+      size: 0,
+      color: DocxColor.white,
+      style: DocxBorder.single,
+    );
+
+    const tableStyle = DocxTableStyle(
+      borderTop: borderNone,
+      borderBottom: borderNone,
+      borderLeft: borderNone,
+      borderRight: borderNone,
+      borderInsideH: borderNone,
+      borderInsideV: borderNone,
+    );
+
+    return DocxFooter(
+      children: [
+        DocxTable(
+          width: 5000, // 100% in pct
+          widthType: DocxWidthType.pct,
+          style: tableStyle,
+          rows: [
+            DocxTableRow(
+              cells: [
+                DocxTableCell(
+                  verticalAlign: DocxVerticalAlign.center,
+                  children: [
+                    DocxImage(
+                      bytes: imageBytes,
+                      extension: imageExtension,
+                      width: imageWidth,
+                      height: imageHeight,
+                      align: DocxAlign.left,
+                    ),
+                  ],
+                ),
+                DocxTableCell(
+                  verticalAlign: DocxVerticalAlign.center,
+                  children: [
+                    DocxParagraph(
+                      align: textAlign,
+                      children: [DocxText(text)],
+                    ),
+                  ],
+                ),
+              ],
+            ),
           ],
         ),
       ],

--- a/packages/docx_creator/lib/src/ast/docx_section.dart
+++ b/packages/docx_creator/lib/src/ast/docx_section.dart
@@ -399,9 +399,7 @@ class DocxFooter extends DocxSection {
     DocxAlign textAlign = DocxAlign.right,
   }) {
     const borderNone = DocxBorderSide(
-      size: 0,
-      color: DocxColor.white,
-      style: DocxBorder.single,
+      style: DocxBorder.none,
     );
 
     const tableStyle = DocxTableStyle(

--- a/packages/docx_creator/lib/src/exporters/docx/generators/header_footer_generator.dart
+++ b/packages/docx_creator/lib/src/exporters/docx/generators/header_footer_generator.dart
@@ -24,6 +24,13 @@ class DocxHeaderFooterGenerator {
             'xmlns:a', 'http://schemas.openxmlformats.org/drawingml/2006/main');
         builder.attribute('xmlns:pic',
             'http://schemas.openxmlformats.org/drawingml/2006/picture');
+        builder.attribute('xmlns:mc',
+            'http://schemas.openxmlformats.org/markup-compatibility/2006');
+        builder.attribute('xmlns:w14',
+            'http://schemas.microsoft.com/office/word/2010/wordml');
+        builder.attribute('xmlns:wp14',
+            'http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing');
+        builder.attribute('mc:Ignorable', 'w14 wp14');
         (state.doc.section!.header as DocxNode).buildXml(builder);
       },
     );
@@ -52,6 +59,13 @@ class DocxHeaderFooterGenerator {
             'xmlns:a', 'http://schemas.openxmlformats.org/drawingml/2006/main');
         builder.attribute('xmlns:pic',
             'http://schemas.openxmlformats.org/drawingml/2006/picture');
+        builder.attribute('xmlns:mc',
+            'http://schemas.openxmlformats.org/markup-compatibility/2006');
+        builder.attribute('xmlns:w14',
+            'http://schemas.microsoft.com/office/word/2010/wordml');
+        builder.attribute('xmlns:wp14',
+            'http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing');
+        builder.attribute('mc:Ignorable', 'w14 wp14');
         (state.doc.section!.footer as DocxNode).buildXml(builder);
       },
     );
@@ -153,6 +167,13 @@ class DocxHeaderFooterGenerator {
             'xmlns:a', 'http://schemas.openxmlformats.org/drawingml/2006/main');
         builder.attribute('xmlns:pic',
             'http://schemas.openxmlformats.org/drawingml/2006/picture');
+        builder.attribute('xmlns:mc',
+            'http://schemas.openxmlformats.org/markup-compatibility/2006');
+        builder.attribute('xmlns:w14',
+            'http://schemas.microsoft.com/office/word/2010/wordml');
+        builder.attribute('xmlns:wp14',
+            'http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing');
+        builder.attribute('mc:Ignorable', 'w14 wp14');
 
         _buildBackgroundImageParagraph(builder, state);
       },

--- a/packages/docx_creator/pubspec.yaml
+++ b/packages/docx_creator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: docx_creator
 description: A developer-first Dart package for creating professional DOCX documents with fluent API, Markdown/HTML parsing, and comprehensive formatting.
-version: 1.2.4
+version: 1.2.5
 repository: https://github.com/alihassan143/flutter-packages
 homepage: https://github.com/alihassan143/flutter-packages/tree/main/packages/docx_creator
 topics:

--- a/packages/docx_creator/test/footer_global_fix_test.dart
+++ b/packages/docx_creator/test/footer_global_fix_test.dart
@@ -1,0 +1,75 @@
+import 'dart:typed_data';
+
+import 'package:docx_creator/docx_creator.dart';
+import 'package:docx_creator/src/core/font_manager.dart';
+import 'package:docx_creator/src/exporters/docx/docx_export_state.dart';
+import 'package:docx_creator/src/exporters/docx/generators/header_footer_generator.dart';
+import 'package:test/test.dart';
+import 'package:xml/xml.dart';
+
+void main() {
+  group('DocxFooter Global Fix', () {
+    test('standard DocxFooter with image generates compliant DrawingML', () {
+      final bytes = Uint8List.fromList([1, 2, 3]);
+      final footer = DocxFooter(
+        children: [
+          DocxImage(
+            bytes: bytes,
+            extension: 'png',
+            width: 50,
+            height: 50,
+            align: DocxAlign.left,
+          ),
+        ],
+      );
+
+      final doc = DocxBuiltDocument(
+        elements: [],
+        section: DocxSectionDef(footer: footer),
+      );
+
+      final state = DocxExportState(doc, FontManager(), DocxIdGenerator());
+
+      // Initialize image collection
+      state.groupedImages['footer'] = [];
+      final img = footer.children.first as DocxImage;
+      final inline = img.asInline;
+      inline.setRelationshipId('rId99', 1);
+      state.groupedImages['footer']!.add(inline);
+
+      final archiveFile = DocxHeaderFooterGenerator.createFooter(state);
+      final xmlString = String.fromCharCodes(archiveFile.content);
+      final document = XmlDocument.parse(xmlString);
+      final ftr = document.rootElement;
+
+      // Verify Root Namespaces
+      expect(
+          ftr.getAttribute('xmlns:mc'),
+          equals(
+              'http://schemas.openxmlformats.org/markup-compatibility/2006'));
+      expect(ftr.getAttribute('xmlns:w14'),
+          equals('http://schemas.microsoft.com/office/word/2010/wordml'));
+      expect(
+          ftr.getAttribute('xmlns:wp14'),
+          equals(
+              'http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing'));
+      expect(ftr.getAttribute('mc:Ignorable'), equals('w14 wp14'));
+
+      // Verify wp:inline attributes
+      final drawing = ftr.findAllElements('w:drawing').first;
+      final inlineElement = drawing.findElements('wp:inline').first;
+
+      expect(inlineElement.getAttribute('distT'), equals('0'));
+      expect(inlineElement.getAttribute('distB'), equals('0'));
+      expect(inlineElement.getAttribute('distL'), equals('114300'));
+      expect(inlineElement.getAttribute('distR'), equals('114300'));
+
+      // Verify wp:effectExtent
+      final effectExtent = inlineElement.findElements('wp:effectExtent').first;
+      expect(effectExtent.getAttribute('l'), equals('0'));
+      expect(effectExtent.getAttribute('t'), equals('0'));
+      expect(effectExtent.getAttribute('r'), equals('0'));
+      expect(effectExtent.getAttribute('b'), equals('0'));
+    });
+  });
+}

--- a/packages/docx_creator/test/footer_image_test.dart
+++ b/packages/docx_creator/test/footer_image_test.dart
@@ -1,0 +1,62 @@
+import 'dart:typed_data';
+
+import 'package:docx_creator/docx_creator.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DocxFooter.imageAndText', () {
+    test('initializes correctly with image and text in a table', () {
+      final imgBytes = Uint8List.fromList([1, 2, 3]);
+      final footer = DocxFooter.imageAndText(
+        imageBytes: imgBytes,
+        imageExtension: 'png',
+        text: 'Footer Text',
+        imageWidth: 50,
+        imageHeight: 50,
+        textAlign: DocxAlign.center,
+      );
+
+      expect(footer.children.length, equals(1));
+      expect(footer.children[0], isA<DocxTable>());
+
+      final table = footer.children[0] as DocxTable;
+      expect(table.width, equals(5000));
+      expect(table.widthType, equals(DocxWidthType.pct));
+
+      // Check borders are invisible
+      final style = table.style;
+      expect(style, isNotNull);
+      expect(style.borderTop!.size, equals(0));
+      expect(style.borderTop!.color, equals(DocxColor.white));
+      expect(style.borderBottom!.size, equals(0));
+      expect(style.borderLeft!.size, equals(0));
+      expect(style.borderRight!.size, equals(0));
+      expect(style.borderInsideH!.size, equals(0));
+      expect(style.borderInsideV!.size, equals(0));
+
+      // Check cells
+      expect(table.rows.length, equals(1));
+      expect(table.rows[0].cells.length, equals(2));
+
+      // Left cell with image
+      final leftCell = table.rows[0].cells[0];
+      expect(leftCell.verticalAlign, equals(DocxVerticalAlign.center));
+      expect(leftCell.children[0], isA<DocxImage>());
+      final image = leftCell.children[0] as DocxImage;
+      expect(image.bytes, equals(imgBytes));
+      expect(image.extension, equals('png'));
+      expect(image.width, equals(50));
+      expect(image.height, equals(50));
+      expect(image.align, equals(DocxAlign.left));
+
+      // Right cell with text
+      final rightCell = table.rows[0].cells[1];
+      expect(rightCell.verticalAlign, equals(DocxVerticalAlign.center));
+      expect(rightCell.children[0], isA<DocxParagraph>());
+      final p = rightCell.children[0] as DocxParagraph;
+      expect(p.align, equals(DocxAlign.center));
+      expect(p.children[0], isA<DocxText>());
+      expect((p.children[0] as DocxText).content, equals('Footer Text'));
+    });
+  });
+}


### PR DESCRIPTION
This PR fixes #90  the issue where images in footers fail to render in Microsoft Word by standardizing DrawingML namespaces and adding mandatory attributes to wp:inline. It also adds a new factory method DocxFooter.imageAndText for easier footer layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes – Version 1.2.5

* **New Features**
  * Introduced a new table-based footer API for combining images and text in document footers.

* **Bug Fixes**
  * Fixed invisible footer and header images by adding missing DrawingML boundary attributes.
  * Enhanced XML namespace declarations for improved OOXML compliance.

* **Tests**
  * Added comprehensive test coverage for footer image rendering and XML compliance validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->