### PR TITLE
fix: pass fontFallback through _buildPreBlock for Unicode support

### DIFF
--- a/packages/htmltopdfwidgets/lib/src/browser/pdf_builder.dart
+++ b/packages/htmltopdfwidgets/lib/src/browser/pdf_builder.dart
@@ -715,7 +715,7 @@ class PdfBuilder {
           const pw.EdgeInsets.all(8),
       child: pw.Text(
         text,
-        style: const pw.TextStyle(
+        style: pw.TextStyle(
           fontSize: 10,
           fontFallback: fontFallback,
         ),

--- a/packages/htmltopdfwidgets/lib/src/browser/pdf_builder.dart
+++ b/packages/htmltopdfwidgets/lib/src/browser/pdf_builder.dart
@@ -717,8 +717,7 @@ class PdfBuilder {
         text,
         style: const pw.TextStyle(
           fontSize: 10,
-
-          // font: // monospace font should be here if available
+          fontFallback: fontFallback,
         ),
       ),
     );


### PR DESCRIPTION
any text inside a <pre> block completely bypasses the fallback font list, meaning Unicode characters (e.g.
Chinese, emoji, symbols) in code blocks would fail to render or fall back to Helvetica, even when the caller has provided fallback fonts. This fixes that by passing in fallbackfont to the pre block

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced rendering of preformatted text in PDFs with improved font fallback support to ensure better text display when specific fonts are unavailable.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alihassan143/flutter-packages/pull/93)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->