### PR TITLE
feat(docx_creator): add DOCX -> Markdown exporter

### DIFF
--- a/packages/docx_creator/lib/docx_creator.dart
+++ b/packages/docx_creator/lib/docx_creator.dart
@@ -37,6 +37,7 @@ export 'src/core/xml_extension.dart';
 // Exporters
 export 'src/exporters/docx_exporter.dart';
 export 'src/exporters/html_exporter.dart';
+export 'src/exporters/markdown_exporter.dart';
 export 'src/exporters/pdf/pdf_exporter.dart';
 // Parsers
 export 'src/parsers/html_parser.dart';

--- a/packages/docx_creator/lib/src/exporters/markdown_exporter.dart
+++ b/packages/docx_creator/lib/src/exporters/markdown_exporter.dart
@@ -87,7 +87,7 @@ class MarkdownExporter {
 
     if (_isCodeBlock(para)) {
       final code = (para.children.single as DocxText).content;
-      return '```\n$code\n```';
+      return '${_codeFence(code)}\n$code\n${_codeFence(code)}';
     }
 
     final content = para.children.map(_convertInline).join();
@@ -95,6 +95,37 @@ class MarkdownExporter {
       return content.split('\n').map((line) => '> $line').join('\n');
     }
 
+    return _escapeLeadingBlockMarker(content);
+  }
+
+  /// A fenced code block's own fence must be longer than any run of
+  /// backticks already inside the code, or the block would close early
+  /// (mirrors [_inlineCodeSpan]'s reasoning for inline code spans).
+  String _codeFence(String code) {
+    final runLengths =
+        RegExp('`+').allMatches(code).map((m) => m.group(0)!.length);
+    final longest = runLengths.isEmpty ? 0 : runLengths.reduce((a, b) => a > b ? a : b);
+    return '`' * (longest < 3 ? 3 : longest + 1);
+  }
+
+  /// Escapes a paragraph-initial sequence that would otherwise be
+  /// re-parsed as block-level Markdown syntax (heading, bullet/ordered
+  /// list, or blockquote) even though it's just plain text content, e.g. a
+  /// paragraph that literally starts with "# " or "1. ". Only punctuation
+  /// can be backslash-escaped in CommonMark, so for an ordered-list marker
+  /// the escaped character is the trailing `.`/`)`, not the leading digit.
+  String _escapeLeadingBlockMarker(String content) {
+    final headingOrBullet =
+        RegExp(r'^(#{1,6}|[-+*]|>)(?=\s)').firstMatch(content);
+    if (headingOrBullet != null) {
+      final marker = headingOrBullet.group(1)!;
+      return '\\$marker${content.substring(marker.length)}';
+    }
+    final ordered = RegExp(r'^\d+([.)])(?=\s)').firstMatch(content);
+    if (ordered != null) {
+      final end = ordered.end;
+      return '${content.substring(0, end - 1)}\\${content.substring(end - 1)}';
+    }
     return content;
   }
 
@@ -145,7 +176,8 @@ class MarkdownExporter {
         .reduce((a, b) => a > b ? a : b);
     if (columnCount == 0) return '';
 
-    final rows = table.rows.map(_convertTableRow).toList();
+    final rows =
+        table.rows.map((row) => _convertTableRow(row, columnCount)).toList();
     final separator = '| ${List.filled(columnCount, '---').join(' | ')} |';
     // A Markdown table requires a header row syntactically, so the first
     // row always becomes the header regardless of DocxTable.hasHeader.
@@ -153,8 +185,14 @@ class MarkdownExporter {
     return rows.join('\n');
   }
 
-  String _convertTableRow(DocxTableRow row) {
+  String _convertTableRow(DocxTableRow row, int columnCount) {
     final cells = row.cells.map(_convertTableCell).toList();
+    // A row with fewer cells than the widest row (e.g. from a collapsed
+    // colSpan) still needs a cell per column, or the row desyncs from the
+    // separator row and produces invalid GFM table syntax.
+    if (cells.length < columnCount) {
+      cells.addAll(List.filled(columnCount - cells.length, ''));
+    }
     return '| ${cells.join(' | ')} |';
   }
 
@@ -185,15 +223,16 @@ class MarkdownExporter {
       var marker = '-';
       var checkboxPrefix = '';
 
-      if (children.isNotEmpty && children.first is DocxCheckbox) {
-        final checkbox = children.first as DocxCheckbox;
-        checkboxPrefix = checkbox.isChecked ? '[x] ' : '[ ] ';
-        children = children.skip(1).toList();
-      } else if (list.isOrdered) {
+      if (list.isOrdered) {
         final start = list.startIndex;
         final next = (orderedCounters[item.level] ?? (start - 1)) + 1;
         orderedCounters[item.level] = next;
         marker = '$next.';
+      }
+      if (children.isNotEmpty && children.first is DocxCheckbox) {
+        final checkbox = children.first as DocxCheckbox;
+        checkboxPrefix = checkbox.isChecked ? '[x] ' : '[ ] ';
+        children = children.skip(1).toList();
       }
 
       final indent = '  ' * item.level;
@@ -273,7 +312,7 @@ class MarkdownExporter {
     final dataUri =
         Uri.dataFromBytes(image.bytes, mimeType: 'image/${image.extension}')
             .toString();
-    final alt = (image.altText ?? '').replaceAll('[', '(').replaceAll(']', ')');
+    final alt = _escapeMarkdown(image.altText ?? '');
     return '![$alt]($dataUri)';
   }
 

--- a/packages/docx_creator/lib/src/exporters/markdown_exporter.dart
+++ b/packages/docx_creator/lib/src/exporters/markdown_exporter.dart
@@ -1,0 +1,309 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import '../../docx_creator.dart';
+import '../utils/file_saver.dart';
+
+/// Converts a [DocxBuiltDocument] into a Markdown string.
+///
+/// The output targets GitHub-Flavored Markdown (GFM) plus a small number of
+/// widely-supported HTML passthrough tags (`<sup>`, `<sub>`, `<u>`) for the
+/// handful of text effects Markdown has no native syntax for. Markdown is a
+/// much smaller format than DOCX, so this is a lossy, best-effort export:
+///
+/// * Floating images, drawing shapes, raw/unmodeled OOXML, section breaks,
+///   and table-of-contents fields have no Markdown equivalent and are
+///   dropped from the output.
+/// * Table cell merges (`colSpan`/`rowSpan`) collapse to a plain cell,
+///   because Markdown tables have no merge syntax.
+/// * A table's first row is always rendered as the header row, because a
+///   Markdown table is not valid without one — this applies even if
+///   [DocxTable.hasHeader] is false.
+/// * Highlighted text uses the `==text==` convention. It renders as plain
+///   text (delimiters included) on parsers that don't support it, which is
+///   an acceptable degradation for a formatting hint.
+///
+/// See the README's "Markdown Export" section for the full support matrix.
+///
+/// ## Basic usage
+/// ```dart
+/// final markdown = MarkdownExporter().export(doc);
+/// await MarkdownExporter().exportToFile(doc, 'output.md');
+/// ```
+class MarkdownExporter {
+  /// Exports [doc] to Markdown and writes it to [filePath].
+  Future<void> exportToFile(DocxBuiltDocument doc, String filePath) async {
+    try {
+      final markdown = export(doc);
+      final bytes = utf8.encode(markdown);
+      await FileSaver.save(filePath, Uint8List.fromList(bytes));
+    } catch (e) {
+      throw DocxExportException(
+        'Failed to write file: $e',
+        targetFormat: 'Markdown',
+        context: filePath,
+      );
+    }
+  }
+
+  /// Exports [doc] to a Markdown string.
+  String export(DocxBuiltDocument doc) {
+    final blocks = <String>[];
+    for (final element in doc.elements) {
+      final block = _convertNode(element);
+      if (block.isNotEmpty) blocks.add(block);
+    }
+
+    final footnoteDefinitions = _convertFootnoteDefinitions(doc);
+    if (footnoteDefinitions.isNotEmpty) blocks.add(footnoteDefinitions);
+
+    return '${blocks.join('\n\n')}\n';
+  }
+
+  // ============================================================
+  // BLOCK-LEVEL NODES
+  // ============================================================
+
+  String _convertNode(DocxNode node) {
+    if (node is DocxParagraph) return _convertParagraph(node);
+    if (node is DocxTable) return _convertTable(node);
+    if (node is DocxList) return _convertList(node);
+    if (node is DocxImage) return _convertBlockImage(node);
+    if (node is DocxDropCap) return _convertDropCap(node);
+    // Shapes, raw XML, TOC fields, and section breaks have no meaningful
+    // Markdown representation and are intentionally omitted.
+    return '';
+  }
+
+  String _convertParagraph(DocxParagraph para) {
+    if (_isHorizontalRule(para)) return '---';
+    if (para.children.isEmpty) return '';
+
+    final headingLevel = _headingLevel(para.styleId);
+    if (headingLevel != null) {
+      final content = para.children.map(_convertInline).join();
+      return '${'#' * headingLevel} $content';
+    }
+
+    if (_isCodeBlock(para)) {
+      final code = (para.children.single as DocxText).content;
+      return '```\n$code\n```';
+    }
+
+    final content = para.children.map(_convertInline).join();
+    if (para.styleId == DocxStyleIds.quote) {
+      return content.split('\n').map((line) => '> $line').join('\n');
+    }
+
+    return content;
+  }
+
+  /// [DocxDocumentBuilder.hr] emits an empty paragraph whose only property
+  /// is a bottom border — that shape is how a horizontal rule survives the
+  /// round trip through the AST, since there is no dedicated `DocxHr` node.
+  bool _isHorizontalRule(DocxParagraph para) =>
+      para.children.isEmpty && para.borderBottomSide != null;
+
+  /// [DocxParagraph.code] produces a paragraph shaded `F5F5F5` with exactly
+  /// one [DocxText.code] child (Courier New, no other formatting) — that
+  /// shape is how a fenced code block is distinguished here from an
+  /// ordinary paragraph whose only content happens to be an inline code
+  /// span (e.g. HTML `<p><code>x</code></p>`, which stays inline).
+  bool _isCodeBlock(DocxParagraph para) {
+    if (para.shadingFill != 'F5F5F5') return false;
+    if (para.children.length != 1) return false;
+    final child = para.children.single;
+    return child is DocxText &&
+        child.fontFamily == 'Courier New' &&
+        !child.isBold &&
+        !child.isItalic &&
+        !child.isLink &&
+        child.decorations.isEmpty;
+  }
+
+  int? _headingLevel(String? styleId) {
+    if (styleId == null || !styleId.startsWith('Heading')) return null;
+    final level = int.tryParse(styleId.substring('Heading'.length));
+    if (level == null || level < 1 || level > 6) return null;
+    return level;
+  }
+
+  String _convertDropCap(DocxDropCap dropCap) {
+    final rest = dropCap.restOfParagraph.map(_convertInline).join();
+    return '${_escapeMarkdown(dropCap.letter)}$rest';
+  }
+
+  String _convertBlockImage(DocxImage image) => _convertInlineImage(
+        image.asInline,
+      );
+
+  String _convertTable(DocxTable table) {
+    if (table.rows.isEmpty) return '';
+
+    final columnCount = table.rows
+        .map((row) => row.cells.length)
+        .reduce((a, b) => a > b ? a : b);
+    if (columnCount == 0) return '';
+
+    final rows = table.rows.map(_convertTableRow).toList();
+    final separator = '| ${List.filled(columnCount, '---').join(' | ')} |';
+    // A Markdown table requires a header row syntactically, so the first
+    // row always becomes the header regardless of DocxTable.hasHeader.
+    rows.insert(1, separator);
+    return rows.join('\n');
+  }
+
+  String _convertTableRow(DocxTableRow row) {
+    final cells = row.cells.map(_convertTableCell).toList();
+    return '| ${cells.join(' | ')} |';
+  }
+
+  String _convertTableCell(DocxTableCell cell) {
+    final parts =
+        cell.children.map<String>(_convertNode).where((s) => s.isNotEmpty);
+    // '|' would terminate the cell early and a literal newline would break
+    // the row, so cell content is flattened onto one line with <br> joins.
+    return parts
+        .join('<br>')
+        .replaceAll('\n', ' ')
+        .replaceAll('|', '\\|')
+        .trim();
+  }
+
+  String _convertList(DocxList list) {
+    if (list.items.isEmpty) return '';
+
+    final buffer = StringBuffer();
+    final orderedCounters = <int, int>{};
+
+    for (final item in list.items) {
+      // Re-entering a level after a deeper nested list resets its counter,
+      // matching how ordered lists restart in Word.
+      orderedCounters.removeWhere((level, _) => level > item.level);
+
+      var children = item.children;
+      var marker = '-';
+      var checkboxPrefix = '';
+
+      if (children.isNotEmpty && children.first is DocxCheckbox) {
+        final checkbox = children.first as DocxCheckbox;
+        checkboxPrefix = checkbox.isChecked ? '[x] ' : '[ ] ';
+        children = children.skip(1).toList();
+      } else if (list.isOrdered) {
+        final start = list.startIndex;
+        final next = (orderedCounters[item.level] ?? (start - 1)) + 1;
+        orderedCounters[item.level] = next;
+        marker = '$next.';
+      }
+
+      final indent = '  ' * item.level;
+      final content = children.map(_convertInline).join();
+      buffer.writeln('$indent$marker $checkboxPrefix$content');
+    }
+
+    return buffer.toString().trimRight();
+  }
+
+  // ============================================================
+  // INLINE NODES
+  // ============================================================
+
+  String _convertInline(DocxInline inline) {
+    if (inline is DocxText) return _convertText(inline);
+    if (inline is DocxLineBreak) return '  \n';
+    if (inline is DocxTab) return '\t';
+    if (inline is DocxInlineImage) return _convertInlineImage(inline);
+    if (inline is DocxCheckbox) return inline.isChecked ? '☑' : '☐';
+    if (inline is DocxFootnoteRef) return '[^${inline.footnoteId}]';
+    if (inline is DocxEndnoteRef) return '[^e${inline.endnoteId}]';
+    // Page number/count fields, inline shapes, and raw inline XML have no
+    // static Markdown equivalent and are intentionally omitted.
+    return '';
+  }
+
+  String _convertText(DocxText text) {
+    if (_isInlineCode(text)) return _inlineCodeSpan(text.content);
+
+    var content = _escapeMarkdown(text.content).replaceAll('\n', '  \n');
+
+    if (text.isSuperscript) content = '<sup>$content</sup>';
+    if (text.isSubscript) content = '<sub>$content</sub>';
+    if (text.isUnderline) content = '<u>$content</u>';
+    if (text.isStrike || text.isDoubleStrike) content = '~~$content~~';
+
+    // Emphasis markers around whitespace-only content are not valid
+    // Markdown emphasis, so leave those runs unwrapped.
+    if (content.trim().isNotEmpty) {
+      if (text.isBold && text.isItalic) {
+        content = '***$content***';
+      } else if (text.isBold) {
+        content = '**$content**';
+      } else if (text.isItalic) {
+        content = '*$content*';
+      }
+    }
+
+    if (text.highlight != DocxHighlight.none) content = '==$content==';
+    if (text.href != null) content = '[$content](${text.href})';
+    return content;
+  }
+
+  bool _isInlineCode(DocxText text) =>
+      text.fontFamily == 'Courier New' &&
+      !text.isBold &&
+      !text.isItalic &&
+      !text.isLink &&
+      text.decorations.isEmpty;
+
+  /// Wraps [content] in a CommonMark code span, choosing a backtick fence
+  /// one character longer than the longest run of backticks already inside
+  /// the content (per the CommonMark code-span spec) so embedded backticks
+  /// can never prematurely close the span.
+  String _inlineCodeSpan(String content) {
+    final runLengths =
+        RegExp('`+').allMatches(content).map((m) => m.group(0)!.length);
+    final fenceLength =
+        runLengths.isEmpty ? 1 : runLengths.reduce((a, b) => a > b ? a : b) + 1;
+    final fence = '`' * fenceLength;
+    final needsPadding = content.startsWith('`') || content.endsWith('`');
+    return needsPadding ? '$fence $content $fence' : '$fence$content$fence';
+  }
+
+  String _convertInlineImage(DocxInlineImage image) {
+    final dataUri =
+        Uri.dataFromBytes(image.bytes, mimeType: 'image/${image.extension}')
+            .toString();
+    final alt = (image.altText ?? '').replaceAll('[', '(').replaceAll(']', ')');
+    return '![$alt]($dataUri)';
+  }
+
+  String _convertFootnoteDefinitions(DocxBuiltDocument doc) {
+    final definitions = <String>[];
+
+    for (final footnote in doc.footnotes ?? const <DocxFootnote>[]) {
+      final content = footnote.content
+          .map<String>(_convertNode)
+          .where((s) => s.isNotEmpty)
+          .join(' ');
+      definitions.add('[^${footnote.footnoteId}]: $content');
+    }
+    for (final endnote in doc.endnotes ?? const <DocxEndnote>[]) {
+      final content = endnote.content
+          .map<String>(_convertNode)
+          .where((s) => s.isNotEmpty)
+          .join(' ');
+      definitions.add('[^e${endnote.endnoteId}]: $content');
+    }
+
+    return definitions.join('\n');
+  }
+
+  /// Escapes characters that would otherwise be interpreted as Markdown
+  /// syntax if they appeared literally in plain text content.
+  String _escapeMarkdown(String text) {
+    return text.replaceAllMapped(
+      RegExp(r'[\\`*_\[\]<>]'),
+      (m) => '\\${m[0]}',
+    );
+  }
+}

--- a/packages/docx_creator/test/markdown_exporter_test.dart
+++ b/packages/docx_creator/test/markdown_exporter_test.dart
@@ -1,0 +1,228 @@
+import 'package:docx_creator/docx_creator.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('MarkdownExporter', () {
+    final exporter = MarkdownExporter();
+
+    test('renders headings at the correct level', () {
+      final doc = DocxBuiltDocument(elements: [
+        DocxParagraph.heading1('Title'),
+        DocxParagraph.heading3('Subsection'),
+      ]);
+
+      final md = exporter.export(doc);
+
+      expect(md, contains('# Title'));
+      expect(md, contains('### Subsection'));
+    });
+
+    test('renders inline formatting', () {
+      final doc = DocxBuiltDocument(elements: [
+        DocxParagraph(children: [
+          DocxText.bold('Bold'),
+          DocxText(' '),
+          DocxText.italic('Italic'),
+          DocxText(' '),
+          DocxText.strike('Struck'),
+          DocxText(' '),
+          DocxText.link('Link', href: 'https://example.com'),
+        ]),
+      ]);
+
+      final md = exporter.export(doc);
+
+      expect(md, contains('**Bold**'));
+      expect(md, contains('*Italic*'));
+      expect(md, contains('~~Struck~~'));
+      // DocxText.link renders as underlined text per its AST constructor,
+      // so the link body carries an explicit <u> tag.
+      expect(md, contains('[<u>Link</u>](https://example.com)'));
+    });
+
+    test('combines bold and italic into a single triple-star run', () {
+      final doc = DocxBuiltDocument(elements: [
+        DocxParagraph(children: [DocxText.boldItalic('Both')]),
+      ]);
+
+      expect(exporter.export(doc), contains('***Both***'));
+    });
+
+    test('renders inline code without escaping its content', () {
+      final doc = DocxBuiltDocument(elements: [
+        DocxParagraph(children: [DocxText.code('a < b && *x*')]),
+      ]);
+
+      final md = exporter.export(doc);
+      expect(md, contains('`a < b && *x*`'));
+    });
+
+    test('picks a wider fence when code content contains backticks', () {
+      final doc = DocxBuiltDocument(elements: [
+        DocxParagraph(children: [DocxText.code('a `b` c')]),
+      ]);
+
+      // A 2-backtick fence is enough since the embedded run is only 1
+      // backtick long; padding is only needed when content itself starts
+      // or ends with a backtick, which isn't the case here.
+      final md = exporter.export(doc);
+      expect(md, contains('``a `b` c``'));
+    });
+
+    test('pads the fence when code content starts with a backtick', () {
+      final doc = DocxBuiltDocument(elements: [
+        DocxParagraph(children: [DocxText.code('`x')]),
+      ]);
+
+      final md = exporter.export(doc);
+      expect(md, contains('`` `x ``'));
+    });
+
+    test('renders a fenced code block from DocxParagraph.code', () {
+      final doc = DocxBuiltDocument(elements: [
+        DocxParagraph.code('print("hi");'),
+      ]);
+
+      final md = exporter.export(doc);
+      expect(md, contains('```\nprint("hi");\n```'));
+    });
+
+    test('renders a blockquote from DocxParagraph.quote', () {
+      final doc = DocxBuiltDocument(elements: [
+        DocxParagraph.quote('Wisdom'),
+      ]);
+
+      // DocxParagraph.quote wraps its text in DocxText.italic.
+      expect(exporter.export(doc), contains('> *Wisdom*'));
+    });
+
+    test('renders a horizontal rule for a builder hr()', () {
+      final doc = DocxDocumentBuilder().p('Before').hr().p('After').build();
+
+      final md = exporter.export(doc);
+      expect(md, contains('\n---\n'));
+    });
+
+    test('escapes Markdown-significant characters in plain text', () {
+      final doc = DocxBuiltDocument(elements: [
+        DocxParagraph(children: [DocxText('1 * 2 [not a link]')]),
+      ]);
+
+      final md = exporter.export(doc);
+      expect(md, contains(r'1 \* 2 \[not a link\]'));
+    });
+
+    test('renders bullet and numbered lists with nesting', () {
+      final doc = DocxBuiltDocument(elements: [
+        DocxList.items([
+          DocxListItem.text('Root'),
+          DocxListItem.text('Nested', level: 1),
+        ], style: DocxListStyle.disc),
+        DocxList.numbered(['First', 'Second']),
+      ]);
+
+      final md = exporter.export(doc);
+      expect(md, contains('- Root'));
+      expect(md, contains('  - Nested'));
+      expect(md, contains('1. First'));
+      expect(md, contains('2. Second'));
+    });
+
+    test('restarts ordered numbering after a nested sublist returns', () {
+      final list = DocxList(
+        isOrdered: true,
+        items: const [
+          DocxListItem([DocxText('a')], level: 0),
+          DocxListItem([DocxText('b')], level: 1),
+          DocxListItem([DocxText('c')], level: 1),
+          DocxListItem([DocxText('d')], level: 0),
+        ],
+      );
+      final doc = DocxBuiltDocument(elements: [list]);
+
+      final md = exporter.export(doc);
+      final lines = md.trim().split('\n');
+      expect(lines[0], '1. a');
+      expect(lines[1], '  1. b');
+      expect(lines[2], '  2. c');
+      expect(lines[3], '2. d');
+    });
+
+    test('renders a task list item from a leading DocxCheckbox', () {
+      final list = DocxList(items: const [
+        DocxListItem(
+          [DocxCheckbox(isChecked: true), DocxText('Done')],
+        ),
+        DocxListItem(
+          [DocxCheckbox(), DocxText('Todo')],
+        ),
+      ]);
+      final doc = DocxBuiltDocument(elements: [list]);
+
+      final md = exporter.export(doc);
+      expect(md, contains('- [x] Done'));
+      expect(md, contains('- [ ] Todo'));
+    });
+
+    test('renders a table with a header separator row', () {
+      final doc = DocxBuiltDocument(elements: [
+        DocxTable.fromData(
+          [
+            ['A', 'B'],
+            ['1', '2'],
+          ],
+        ),
+      ]);
+
+      final md = exporter.export(doc);
+      final lines = md.trim().split('\n');
+      // DocxTable.fromData bolds the header row by default.
+      expect(lines[0], '| **A** | **B** |');
+      expect(lines[1], '| --- | --- |');
+      expect(lines[2], '| 1 | 2 |');
+    });
+
+    test('escapes pipe characters inside table cells', () {
+      final doc = DocxBuiltDocument(elements: [
+        DocxTable.fromData([
+          ['a|b', 'c'],
+        ]),
+      ]);
+
+      expect(exporter.export(doc), contains(r'a\|b'));
+    });
+
+    test('renders footnote references and trailing definitions', () {
+      final doc = DocxBuiltDocument(
+        elements: [
+          DocxParagraph(children: [
+            DocxText('See note'),
+            const DocxFootnoteRef(footnoteId: 1),
+          ]),
+        ],
+        footnotes: [
+          DocxFootnote(
+            footnoteId: 1,
+            content: [DocxParagraph.text('Explanation.')],
+          ),
+        ],
+      );
+
+      final md = exporter.export(doc);
+      expect(md, contains('[^1]'));
+      expect(md, contains('[^1]: Explanation.'));
+    });
+
+    test('round trip through file export and back produces the same string',
+        () async {
+      final doc = DocxBuiltDocument(elements: [
+        DocxParagraph.heading1('Report'),
+        DocxParagraph.text('Body text.'),
+      ]);
+
+      final expected = exporter.export(doc);
+      expect(expected, startsWith('# Report'));
+      expect(expected, contains('Body text.'));
+    });
+  });
+}

--- a/packages/docx_creator/test/markdown_exporter_test.dart
+++ b/packages/docx_creator/test/markdown_exporter_test.dart
@@ -1,3 +1,6 @@
+import 'dart:io';
+import 'dart:typed_data';
+
 import 'package:docx_creator/docx_creator.dart';
 import 'package:test/test.dart';
 
@@ -87,6 +90,32 @@ void main() {
       expect(md, contains('```\nprint("hi");\n```'));
     });
 
+    test('widens the code-block fence past any backtick run in the code',
+        () {
+      final doc = DocxBuiltDocument(elements: [
+        DocxParagraph.code('```\nnested fence\n```'),
+      ]);
+
+      final md = exporter.export(doc);
+      // The code contains a run of 3 backticks, so the wrapping fence must
+      // be at least 4 long or the block would close early.
+      expect(md, contains('````\n```\nnested fence\n```\n````'));
+    });
+
+    test('escapes a paragraph that literally starts with a heading/list '
+        'marker', () {
+      final doc = DocxBuiltDocument(elements: [
+        DocxParagraph.text('# Not a heading'),
+        DocxParagraph.text('1. Not a list item'),
+        DocxParagraph.text('- Not a bullet'),
+      ]);
+
+      final md = exporter.export(doc);
+      expect(md, contains(r'\# Not a heading'));
+      expect(md, contains(r'1\. Not a list item'));
+      expect(md, contains(r'\- Not a bullet'));
+    });
+
     test('renders a blockquote from DocxParagraph.quote', () {
       final doc = DocxBuiltDocument(elements: [
         DocxParagraph.quote('Wisdom'),
@@ -164,6 +193,19 @@ void main() {
       expect(md, contains('- [ ] Todo'));
     });
 
+    test('keeps a numeric marker for a task item inside an ordered list',
+        () {
+      final list = DocxList(
+        isOrdered: true,
+        items: const [
+          DocxListItem([DocxCheckbox(isChecked: true), DocxText('Done')]),
+        ],
+      );
+      final doc = DocxBuiltDocument(elements: [list]);
+
+      expect(exporter.export(doc), contains('1. [x] Done'));
+    });
+
     test('renders a table with a header separator row', () {
       final doc = DocxBuiltDocument(elements: [
         DocxTable.fromData(
@@ -192,6 +234,35 @@ void main() {
       expect(exporter.export(doc), contains(r'a\|b'));
     });
 
+    test('pads a row with fewer cells than the widest row', () {
+      final doc = DocxBuiltDocument(elements: [
+        DocxTable(rows: [
+          DocxTableRow(cells: [
+            DocxTableCell.text('A'),
+            DocxTableCell.text('B'),
+          ]),
+          // Simulates a collapsed colSpan: only one cell in this row.
+          DocxTableRow(cells: [DocxTableCell.text('merged')]),
+        ]),
+      ]);
+
+      final lines = exporter.export(doc).trim().split('\n');
+      expect(lines[2], '| merged |  |');
+    });
+
+    test('escapes literal brackets in image alt text instead of mangling '
+        'them', () {
+      final doc = DocxBuiltDocument(elements: [
+        DocxImage(
+          bytes: Uint8List(0),
+          extension: 'png',
+          altText: 'Diagram [draft]',
+        ),
+      ]);
+
+      expect(exporter.export(doc), contains(r'![Diagram \[draft\]]'));
+    });
+
     test('renders footnote references and trailing definitions', () {
       final doc = DocxBuiltDocument(
         elements: [
@@ -213,8 +284,7 @@ void main() {
       expect(md, contains('[^1]: Explanation.'));
     });
 
-    test('round trip through file export and back produces the same string',
-        () async {
+    test('exportToFile writes the same content export() returns', () async {
       final doc = DocxBuiltDocument(elements: [
         DocxParagraph.heading1('Report'),
         DocxParagraph.text('Body text.'),
@@ -223,6 +293,15 @@ void main() {
       final expected = exporter.export(doc);
       expect(expected, startsWith('# Report'));
       expect(expected, contains('Body text.'));
+
+      final tempDir = await Directory.systemTemp.createTemp('markdown_exporter_');
+      try {
+        final path = '${tempDir.path}/report.md';
+        await exporter.exportToFile(doc, path);
+        expect(await File(path).readAsString(), expected);
+      } finally {
+        await tempDir.delete(recursive: true);
+      }
     });
   });
 }


### PR DESCRIPTION
Closes #109.

## Summary
- Adds `MarkdownExporter` (`lib/src/exporters/markdown_exporter.dart`), the missing reverse direction of `MarkdownParser` — docx_creator could go Markdown → DOCX and DOCX → HTML, but not DOCX → Markdown.
- Mirrors `HtmlExporter`'s public shape: `export(doc) -> String` and `exportToFile(doc, path)`.
- Covers: headings (H1-H6), bold/italic/bold+italic/strikethrough, inline code (CommonMark-correct backtick-fence sizing, including padding when content starts/ends with a backtick), links, superscript/subscript/underline (via `<sup>`/`<sub>`/`<u>` passthrough), highlighted text (`==text==`), fenced code blocks, blockquotes, horizontal rules, nested bullet/numbered lists (with per-level ordered-numbering restart), GFM task-list items, tables (with a synthesized header separator row, since Markdown tables require one), inline/block images (as data URIs, matching `HtmlExporter`'s approach for portability), and footnote/endnote references with trailing `[^n]: ...` definitions.
- Escapes Markdown-significant characters in plain text content so arbitrary DOCX text round-trips safely.
- Documents (in the class doc) the handful of DOCX constructs Markdown has no equivalent for and are intentionally dropped: floating images/shapes, raw OOXML, section breaks, and TOC fields.

## Test plan
- [x] `dart analyze` clean
- [x] New `test/markdown_exporter_test.dart` (17 tests) covering headings, inline formatting, inline-code edge cases, code blocks, blockquotes, hr, escaping, nested/ordered/task lists, tables, and footnotes
- [x] Full existing suite still green (348 passing, 1 pre-existing skip) — no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Markdown export support for DOCX documents.
  * Supports headings, formatting, lists, tables, links, code blocks, blockquotes, task items, footnotes, and Markdown escaping.
  * Added the ability to save exported Markdown files directly.

* **Tests**
  * Added coverage for Markdown formatting, document structures, escaping, and file export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->