### PR TITLE
fix(docx_creator): HTML table parser respects named/rgb colors, <tr style>, and <thead>

### DIFF
--- a/packages/docx_creator/lib/src/parsers/html/color_utils.dart
+++ b/packages/docx_creator/lib/src/parsers/html/color_utils.dart
@@ -100,6 +100,25 @@ class ColorUtils {
     return null;
   }
 
+  /// Extracts a color-valued CSS property (e.g. `color`, `background-color`)
+  /// from a style string and resolves it to a hex string via [parseColor],
+  /// so named colors (`lightgreen`), `rgb()`/`rgba()`, and 3-digit hex are
+  /// all recognized — not just literal 6-digit hex.
+  ///
+  /// The negative lookbehind on [property] avoids `color` matching inside
+  /// `background-color`.
+  static String? parseCssColorProperty(String style, String property) {
+    final regex = RegExp(
+      '(?<![-a-zA-Z])$property:\\s*[\'"]?'
+      r"(#[A-Fa-f0-9]{3,8}|rgba?\([0-9.,\s]+\)|[a-zA-Z]+)"
+      '[\'"]?',
+      caseSensitive: false,
+    );
+    final match = regex.firstMatch(style);
+    if (match == null) return null;
+    return parseColor(match.group(1)!);
+  }
+
   /// W3C CSS3 Extended Color Keywords (141 named colors).
   static const _cssColors = <String, String>{
     // Basic colors

--- a/packages/docx_creator/lib/src/parsers/html/table_parser.dart
+++ b/packages/docx_creator/lib/src/parsers/html/table_parser.dart
@@ -26,9 +26,11 @@ class HtmlTableParser {
       final childTag = child.localName?.toLowerCase();
 
       if (childTag == 'tbody' || childTag == 'thead' || childTag == 'tfoot') {
+        final isHeaderSection = childTag == 'thead';
         for (var tr in child.children) {
           if (tr.localName?.toLowerCase() == 'tr') {
-            final row = await _parseTableRow(tr);
+            final row =
+                await _parseTableRow(tr, isHeaderSection: isHeaderSection);
             if (row != null) rows.add(row);
           }
         }
@@ -72,38 +74,58 @@ class HtmlTableParser {
     );
   }
 
-  Future<DocxTableRow?> _parseTableRow(dom.Element tr) async {
-    final cells = <DocxTableCell>[];
+  Future<DocxTableRow?> _parseTableRow(
+    dom.Element tr, {
+    bool isHeaderSection = false,
+  }) async {
+    final rowStyle = context.mergeStyles(tr.attributes['style'], tr.classes);
+    final rowShadingFill =
+        ColorUtils.parseCssColorProperty(rowStyle, 'background-color');
+    final rowColorHex = ColorUtils.parseCssColorProperty(rowStyle, 'color');
 
+    final cells = <DocxTableCell>[];
     for (var child in tr.children) {
       final tag = child.localName?.toLowerCase();
       if (tag == 'td' || tag == 'th') {
-        final cell = await _parseTableCell(child, isHeader: tag == 'th');
+        final cell = await _parseTableCell(
+          child,
+          isHeader: isHeaderSection || tag == 'th',
+          rowShadingFill: rowShadingFill,
+          rowColorHex: rowColorHex,
+        );
         cells.add(cell);
       }
     }
 
     if (cells.isEmpty) return null;
-    return DocxTableRow(cells: cells);
+    return DocxTableRow(cells: cells, isHeader: isHeaderSection);
   }
 
-  Future<DocxTableCell> _parseTableCell(dom.Element td,
-      {bool isHeader = false}) async {
+  Future<DocxTableCell> _parseTableCell(
+    dom.Element td, {
+    bool isHeader = false,
+    String? rowShadingFill,
+    String? rowColorHex,
+  }) async {
     final style = context.mergeStyles(td.attributes['style'], td.classes);
 
-    String? shadingFill;
-    final bgMatch =
-        RegExp(r'background-color:\s*#([A-Fa-f0-9]{6})').firstMatch(style);
-    if (bgMatch != null) {
-      shadingFill = bgMatch.group(1);
-    } else if (isHeader) {
-      shadingFill = 'E0E0E0';
-    }
+    // A cell's own background wins over its row's, which wins over the
+    // default header shading.
+    final shadingFill =
+        ColorUtils.parseCssColorProperty(style, 'background-color') ??
+            rowShadingFill ??
+            (isHeader ? 'E0E0E0' : null);
+    final colorHex =
+        ColorUtils.parseCssColorProperty(style, 'color') ?? rowColorHex;
 
     final colSpan = int.tryParse(td.attributes['colspan'] ?? '1') ?? 1;
     final rowSpan = int.tryParse(td.attributes['rowspan'] ?? '1') ?? 1;
 
-    final content = await _parseCellContent(td.nodes, isHeader: isHeader);
+    final content = await _parseCellContent(
+      td.nodes,
+      isHeader: isHeader,
+      colorHex: colorHex,
+    );
 
     return DocxTableCell(
       children: content,
@@ -121,14 +143,27 @@ class HtmlTableParser {
     );
   }
 
-  Future<List<DocxBlock>> _parseCellContent(List<dom.Node> nodes,
-      {bool isHeader = false}) async {
+  Future<List<DocxBlock>> _parseCellContent(
+    List<dom.Node> nodes, {
+    bool isHeader = false,
+    String? colorHex,
+  }) async {
     if (blockParser != null) {
-      final results = await blockParser!.parseChildren(nodes);
+      // Seed the row/cell's own text color and header weight as inherited
+      // style, the same way a nested <span style="..."> would inherit from
+      // an ancestor, so it reaches text nodes even when the cell has no
+      // per-run style of its own.
+      final seedContext = HtmlStyleContext(
+        colorHex: colorHex,
+        fontWeight: isHeader ? DocxFontWeight.bold : DocxFontWeight.normal,
+      );
+      final results = await blockParser!
+          .parseChildren(nodes, styleContext: seedContext);
       return results.whereType<DocxBlock>().toList();
     }
     final blocks = <DocxBlock>[];
     final inlines = <DocxInline>[];
+    final color = colorHex != null ? DocxColor(colorHex) : null;
 
     void flushInlines() {
       if (inlines.isNotEmpty) {
@@ -141,7 +176,9 @@ class HtmlTableParser {
       if (node is dom.Text) {
         final text = node.text.trim();
         if (text.isNotEmpty) {
-          inlines.add(isHeader ? DocxText.bold(text) : DocxText(text));
+          inlines.add(isHeader
+              ? DocxText.bold(text, color: color)
+              : DocxText(text, color: color));
         }
       } else if (node is dom.Element) {
         final tag = node.localName?.toLowerCase();

--- a/packages/docx_creator/test/html_table_color_test.dart
+++ b/packages/docx_creator/test/html_table_color_test.dart
@@ -1,0 +1,67 @@
+import 'package:docx_creator/docx_creator.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('HTML table row/cell color parsing', () {
+    test('applies a named background-color and text color from <tr style>',
+        () async {
+      final html = '''
+<table border="1">
+  <tr style="background-color: #4472C4; color: white;">
+    <th>Name</th>
+    <th>Status</th>
+  </tr>
+  <tr>
+    <td>Task 1</td>
+    <td style="background-color: lightgreen;">Complete</td>
+  </tr>
+</table>
+''';
+      final nodes = await DocxParser.fromHtml(html);
+      final table = nodes.single as DocxTable;
+
+      final headerRow = table.rows[0];
+      for (final cell in headerRow.cells) {
+        expect(cell.shadingFill, '4472C4');
+        final para = cell.children.single as DocxParagraph;
+        final text = para.children.single as DocxText;
+        expect(text.color?.hex, 'FFFFFF');
+      }
+
+      final bodyRow = table.rows[1];
+      expect(bodyRow.cells[0].shadingFill, isNull);
+      // Named color, not just literal hex.
+      expect(bodyRow.cells[1].shadingFill, '90EE90');
+    });
+
+    test('a cell background overrides its row background', () async {
+      final html = '''
+<table>
+  <tr style="background-color: red;">
+    <td style="background-color: blue;">Cell</td>
+    <td>Other</td>
+  </tr>
+</table>
+''';
+      final nodes = await DocxParser.fromHtml(html);
+      final table = nodes.single as DocxTable;
+
+      expect(table.rows[0].cells[0].shadingFill, '0000FF');
+      expect(table.rows[0].cells[1].shadingFill, 'FF0000');
+    });
+
+    test('rows inside <thead> are marked as header rows', () async {
+      final html = '''
+<table>
+  <thead><tr><th>Col</th></tr></thead>
+  <tbody><tr><td>Val</td></tr></tbody>
+</table>
+''';
+      final nodes = await DocxParser.fromHtml(html);
+      final table = nodes.single as DocxTable;
+
+      expect(table.rows[0].isHeader, isTrue);
+      expect(table.rows[1].isHeader, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Closes #100.

## Summary
- `ColorUtils.parseCssColorProperty` extracts a color-valued CSS property (`color`, `background-color`) through the same named-color/`rgb()`/hex resolution already used elsewhere in the parser, instead of the table cell parser's previous literal-6-digit-hex-only regex.
- `<tr style="...">` background/text color now apply to every cell in the row (a cell's own style still wins).
- Row/cell text color reaches actual text runs via `HtmlStyleContext` inheritance through the live `HtmlBlockParser.parseChildren` path — table cell content parsing goes through that path in all real usage (`setBlockParser` is always called), so a fix that only touched the parser's internal manual fallback path would not have changed real output. Confirmed this by testing before/after with the block-parser path active.
- Rows inside `<thead>` are now marked `DocxTableRow.isHeader = true`.

Fixes the README's own documented example, which never worked as shown:
```html
<tr style="background-color: #4472C4; color: white;"><th>Name</th></tr>
<td style="background-color: lightgreen;">Complete</td>
```

## Test plan
- [x] `dart analyze` clean
- [x] New `test/html_table_color_test.dart` (3 tests): named/hex row+cell color with precedence, cell-over-row override, `<thead>` marking
- [x] Full existing suite green (342 passing, 1 pre-existing skip), no regressions