### PR TITLE
fix(docx_creator): HTML parser collapses whitespace, merges loose inline siblings

### DIFF
--- a/packages/docx_creator/lib/src/parsers/html/block_parser.dart
+++ b/packages/docx_creator/lib/src/parsers/html/block_parser.dart
@@ -29,21 +29,48 @@ class HtmlBlockParser {
   }
 
   /// Parse child nodes into DocxNode elements.
+  ///
+  /// Consecutive siblings that don't produce a block of their own — text
+  /// nodes and inline elements like `<span>`/`<b>` sitting directly next to
+  /// a block sibling (e.g. `<div><p>A</p>loose <span>text</span></div>`) —
+  /// are accumulated and merged into a single paragraph, the same way a
+  /// browser lays them out on one line, instead of each becoming its own
+  /// separate paragraph.
   Future<List<DocxNode>> parseChildren(List<dom.Node> nodes,
       {HtmlStyleContext? styleContext}) async {
+    final ctx = styleContext ?? const HtmlStyleContext();
     final results = <DocxNode>[];
-    for (var node in nodes) {
-      final parsed = await parseNode(node, styleContext: styleContext);
-      results.addAll(parsed);
+    final inlineBuffer = <DocxInline>[];
+
+    void flushInlineBuffer() {
+      if (inlineBuffer.isEmpty) return;
+      results.add(DocxParagraph(children: List.of(inlineBuffer)));
+      inlineBuffer.clear();
     }
+
+    for (var node in nodes) {
+      final isLooseInline = node is dom.Text ||
+          (node is dom.Element && !isBlockTag(node.localName?.toLowerCase()));
+
+      if (isLooseInline) {
+        inlineBuffer.addAll(await _inlineParser.parseInline(node, context: ctx));
+        continue;
+      }
+
+      flushInlineBuffer();
+      results.addAll(await parseNode(node, styleContext: styleContext));
+    }
+    flushInlineBuffer();
+
     return results;
   }
 
-  /// Parse a single DOM node.
+  /// Parse a single DOM node in isolation (i.e. not as part of a run of
+  /// sibling inline content — see [parseChildren] for that merging).
   Future<List<DocxNode>> parseNode(dom.Node node,
       {HtmlStyleContext? styleContext}) async {
     if (node is dom.Text) {
-      final text = node.text.trim();
+      final text = collapseHtmlWhitespace(node.text).trim();
       if (text.isEmpty) return [];
       final built = DocumentBuilder.buildBlockElement(
         tag: 'p',

--- a/packages/docx_creator/lib/src/parsers/html/inline_parser.dart
+++ b/packages/docx_creator/lib/src/parsers/html/inline_parser.dart
@@ -107,10 +107,16 @@ class HtmlInlineParser {
   }
 
   List<DocxInline> _parseTextNode(String text, HtmlStyleContext ctx) {
-    if (text.isEmpty) return [];
+    // HTML collapses runs of whitespace (including newlines from
+    // pretty-printed markup) into a single space; only whitespace-only
+    // text nodes (indentation between sibling tags) are dropped entirely.
+    final collapsed = collapseHtmlWhitespace(text);
+    if (collapsed.trim().isEmpty) return [];
 
-    // Check for checkbox patterns
-    if (text.startsWith('[ ] ')) {
+    // Check for checkbox patterns (allow leading whitespace collapsed
+    // above from e.g. indentation before the marker).
+    final leftTrimmed = collapsed.trimLeft();
+    if (leftTrimmed.startsWith('[ ] ')) {
       return [
         DocumentBuilder.buildCheckbox(
           isChecked: false,
@@ -119,9 +125,10 @@ class HtmlInlineParser {
           fontStyle: ctx.fontStyle,
           color: ctx.colorHex != null ? DocxColor(ctx.colorHex!) : null,
         ),
-        createText(text.substring(4), ctx)
+        createText(leftTrimmed.substring(4), ctx)
       ];
-    } else if (text.startsWith('[x] ') || text.startsWith('[X] ')) {
+    } else if (leftTrimmed.startsWith('[x] ') ||
+        leftTrimmed.startsWith('[X] ')) {
       return [
         DocumentBuilder.buildCheckbox(
           isChecked: true,
@@ -130,11 +137,11 @@ class HtmlInlineParser {
           fontStyle: ctx.fontStyle,
           color: ctx.colorHex != null ? DocxColor(ctx.colorHex!) : null,
         ),
-        createText(text.substring(4), ctx)
+        createText(leftTrimmed.substring(4), ctx)
       ];
     }
 
-    return [createText(text, ctx)];
+    return [createText(collapsed, ctx)];
   }
 
   List<DocxInline> _parseInput(dom.Element node, HtmlStyleContext newCtx) {

--- a/packages/docx_creator/lib/src/parsers/html/parser_context.dart
+++ b/packages/docx_creator/lib/src/parsers/html/parser_context.dart
@@ -1,5 +1,17 @@
 import 'package:html/dom.dart' as dom;
 
+/// Collapses runs of HTML whitespace (space, tab, newline, carriage
+/// return, form feed) into a single space, matching how a browser
+/// collapses whitespace in normal (non-`<pre>`) text content.
+///
+/// This intentionally does not trim the result — a single leading or
+/// trailing space is often significant (e.g. the space between
+/// `<b>bold</b> text`), so trimming is left to call sites that know
+/// whether they're at a boundary where it's safe to drop.
+String collapseHtmlWhitespace(String text) {
+  return text.replaceAll(RegExp(r'[ \t\r\n\f]+'), ' ');
+}
+
 /// Shared context for all HTML parser modules.
 ///
 /// Holds the CSS class map and provides access to parsed styles.

--- a/packages/docx_creator/test/html_whitespace_test.dart
+++ b/packages/docx_creator/test/html_whitespace_test.dart
@@ -1,0 +1,69 @@
+import 'package:docx_creator/docx_creator.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('HTML whitespace collapsing', () {
+    test('collapses internal newlines/indentation into a single space',
+        () async {
+      final html = '<p>Hello\n   World</p>';
+      final nodes = await DocxParser.fromHtml(html);
+
+      final para = nodes.single as DocxParagraph;
+      final text = para.children.single as DocxText;
+      expect(text.content, 'Hello World');
+    });
+
+    test('drops whitespace-only text nodes between block siblings',
+        () async {
+      final html = '<div>\n  <p>A</p>\n  <p>B</p>\n</div>';
+      final nodes = await DocxParser.fromHtml(html);
+
+      expect(nodes.length, 2);
+      expect(
+        (nodes[0] as DocxParagraph).children.whereType<DocxText>().single.content,
+        'A',
+      );
+      expect(
+        (nodes[1] as DocxParagraph).children.whereType<DocxText>().single.content,
+        'B',
+      );
+    });
+
+    test('preserves a single significant space between inline runs',
+        () async {
+      final html = '<p><b>Bold</b> and <i>italic</i></p>';
+      final nodes = await DocxParser.fromHtml(html);
+
+      final para = nodes.single as DocxParagraph;
+      final combined =
+          para.children.whereType<DocxText>().map((t) => t.content).join();
+      expect(combined, 'Bold and italic');
+    });
+  });
+
+  group('HTML loose inline sibling merging', () {
+    test('merges loose text and inline siblings next to a block into one '
+        'paragraph', () async {
+      final html = '<div><p>A</p>loose <span>text</span></div>';
+      final nodes = await DocxParser.fromHtml(html);
+
+      expect(nodes.length, 2);
+      expect(nodes[0], isA<DocxParagraph>());
+
+      final second = nodes[1] as DocxParagraph;
+      final combined = second.children
+          .whereType<DocxText>()
+          .map((t) => t.content)
+          .join();
+      expect(combined, 'loose text');
+    });
+
+    test('a bare block-level body still parses each block separately',
+        () async {
+      final html = '<h1>Title</h1><p>Body</p>';
+      final nodes = await DocxParser.fromHtml(html);
+
+      expect(nodes.length, 2);
+    });
+  });
+}


### PR DESCRIPTION
Closes #101.

## Summary
1. **Whitespace wasn't collapsed.** Text nodes went through raw, so typical pretty-printed HTML like `<p>Hello\n   World</p>` produced the literal run `"Hello\n   World"` instead of `"Hello World"`. Added a shared `collapseHtmlWhitespace()` helper (space/tab/CR/LF/FF runs -> single space, matching browser behavior for normal text; intentionally not trimmed, since a single boundary space next to inline siblings is often significant).
2. **Loose inline siblings next to a block split into the wrong paragraphs.** `parseChildren()` previously called `parseNode()` independently per DOM child, so `<div><p>A</p>loose <span>text</span></div>` produced three paragraphs ("A", "loose", "text") instead of two ("A", "loose text"). `parseChildren()` now buffers consecutive non-block-tag siblings (text nodes and inline elements like `<span>`/`<b>`) and flushes them as a single merged paragraph, mirroring how a browser lays inline content out on one line.

## Test plan
- [x] `dart analyze` clean
- [x] New `test/html_whitespace_test.dart` (5 tests): internal collapsing, whitespace-only nodes between blocks being dropped, boundary-space preservation, sibling merging, and a sanity check that ordinary block-only markup still parses one node per block
- [x] Full existing suite green (332 passing, 1 pre-existing skip), no regressions — this touches a shared code path (`parseChildren`) so I verified the full suite specifically for this change