### PR TITLE
fix(docx_creator): HTML parser CSS unit conversion, case sensitivity, hsl(), grouped selectors, margin/padding

### DIFF
--- a/packages/docx_creator/lib/src/parsers/html/block_parser.dart
+++ b/packages/docx_creator/lib/src/parsers/html/block_parser.dart
@@ -138,6 +138,9 @@ class HtmlBlockParser {
             borderBottomSide: blockStyles.borderBottom,
             borderLeft: blockStyles.borderLeft,
             borderRight: blockStyles.borderRight,
+            indentLeft: blockStyles.indentLeft,
+            indentRight: blockStyles.indentRight,
+            indentFirstLine: blockStyles.indentFirstLine,
           )
         ];
 
@@ -183,6 +186,10 @@ class HtmlBlockParser {
               borderBottomSide: blockStyles.borderBottom,
               borderLeft: blockStyles.borderLeft,
               borderRight: blockStyles.borderRight,
+              indentLeft: blockStyles.indentLeft ?? built.indentLeft,
+              indentRight: blockStyles.indentRight ?? built.indentRight,
+              indentFirstLine:
+                  blockStyles.indentFirstLine ?? built.indentFirstLine,
             )
           ];
         }
@@ -195,6 +202,9 @@ class HtmlBlockParser {
             children: children,
             shadingFill: blockStyles.shadingFill,
             align: blockStyles.align,
+            indentLeft: blockStyles.indentLeft,
+            indentRight: blockStyles.indentRight,
+            indentFirstLine: blockStyles.indentFirstLine,
           )
         ];
     }
@@ -224,7 +234,8 @@ class HtmlBlockParser {
     DocxAlign align = DocxAlign.left;
 
     final bgMatch = RegExp(
-            r"background-color:\s*['\x22]?(#[A-Fa-f0-9]{3,6}|rgb\([0-9,\s]+\)|rgba\([0-9.,\s]+\)|[a-zA-Z]+)['\x22]?")
+            r"background-color:\s*['\x22]?(#[A-Fa-f0-9]{3,6}|rgba?\([0-9.,\s]+\)|hsla?\([0-9.,%\s]+\)|[a-zA-Z]+)['\x22]?",
+            caseSensitive: false)
         .firstMatch(style);
     if (bgMatch != null) {
       final val = bgMatch.group(1);
@@ -233,12 +244,19 @@ class HtmlBlockParser {
       }
     }
 
-    if (style.contains('text-align: center')) {
-      align = DocxAlign.center;
-    } else if (style.contains('text-align: right')) {
-      align = DocxAlign.right;
-    } else if (style.contains('text-align: justify')) {
-      align = DocxAlign.justify;
+    final alignMatch =
+        RegExp(r'text-align\s*:\s*(\w+)', caseSensitive: false)
+            .firstMatch(style);
+    switch (alignMatch?.group(1)?.toLowerCase()) {
+      case 'center':
+        align = DocxAlign.center;
+        break;
+      case 'right':
+        align = DocxAlign.right;
+        break;
+      case 'justify':
+        align = DocxAlign.justify;
+        break;
     }
 
     return HtmlBlockStyles(
@@ -252,7 +270,24 @@ class HtmlBlockParser {
           ColorUtils.parseCssBorderProperty(style, 'border'),
       borderRight: ColorUtils.parseCssBorderProperty(style, 'border-right') ??
           ColorUtils.parseCssBorderProperty(style, 'border'),
+      indentLeft: _lengthPropertyTwips(style, 'margin-left') ??
+          _lengthPropertyTwips(style, 'padding-left'),
+      indentRight: _lengthPropertyTwips(style, 'margin-right') ??
+          _lengthPropertyTwips(style, 'padding-right'),
+      indentFirstLine: _lengthPropertyTwips(style, 'text-indent'),
     );
+  }
+
+  /// Reads a CSS length property (e.g. `margin-left: 40px`) and converts it
+  /// to twips (1/20th of a point), or null if the property isn't present.
+  int? _lengthPropertyTwips(String style, String property) {
+    final match = RegExp(
+      '$property\\s*:\\s*(-?[\\d.]+\\s*(?:px|pt|em|rem|%)?)',
+      caseSensitive: false,
+    ).firstMatch(style);
+    if (match == null) return null;
+    final points = ColorUtils.parseCssLengthToPoints(match.group(1)!);
+    return points != null ? (points * 20).round() : null;
   }
 
   String _getText(dom.Node node) {

--- a/packages/docx_creator/lib/src/parsers/html/color_utils.dart
+++ b/packages/docx_creator/lib/src/parsers/html/color_utils.dart
@@ -31,6 +31,20 @@ class ColorUtils {
       }
     }
 
+    // Handle hsl/hsla
+    if (trimmed.startsWith('hsl')) {
+      final match = RegExp(
+              r'hsla?\s*\(\s*([\d.]+)\s*,\s*([\d.]+)%\s*,\s*([\d.]+)%(?:\s*,\s*[\d.]+)?\s*\)')
+          .firstMatch(trimmed);
+      if (match != null) {
+        final h = double.tryParse(match.group(1) ?? '0') ?? 0;
+        final s = double.tryParse(match.group(2) ?? '0') ?? 0;
+        final l = double.tryParse(match.group(3) ?? '0') ?? 0;
+        final rgb = _hslToRgb(h, s / 100, l / 100);
+        return '${toHex(rgb[0])}${toHex(rgb[1])}${toHex(rgb[2])}';
+      }
+    }
+
     // CSS named colors lookup
     final namedColor = _cssColors[trimmed];
     if (namedColor != null) return namedColor;
@@ -46,6 +60,68 @@ class ColorUtils {
   /// Convert int to 2-digit hex string.
   static String toHex(int val) {
     return val.toRadixString(16).padLeft(2, '0').toUpperCase();
+  }
+
+  /// Default font size (points) used as the base for relative CSS length
+  /// units (`em`, `rem`, `%`) when no better context is available.
+  static const double defaultBaseFontSizePt = 12;
+
+  /// Converts a CSS length value (e.g. `16px`, `1.2em`, `12pt`, `150%`) to
+  /// points. Relative units (`em`/`rem`/`%`) resolve against
+  /// [defaultBaseFontSizePt], since this parser doesn't track a full CSS
+  /// cascade of computed font sizes.
+  ///
+  /// Returns null if [value] isn't a recognizable CSS length.
+  static double? parseCssLengthToPoints(String value) {
+    final match =
+        RegExp(r'^(-?[\d.]+)\s*(px|pt|em|rem|%)?$').firstMatch(value.trim());
+    if (match == null) return null;
+    final number = double.tryParse(match.group(1)!);
+    if (number == null) return null;
+
+    switch (match.group(2)) {
+      case 'pt':
+      case null: // Bare numbers are historically treated as points here.
+        return number;
+      case 'px':
+        return number * 0.75; // 96px == 1in == 72pt
+      case 'em':
+      case 'rem':
+        return number * defaultBaseFontSizePt;
+      case '%':
+        return number / 100 * defaultBaseFontSizePt;
+      default:
+        return null;
+    }
+  }
+
+  /// Converts HSL (hue in degrees, saturation/lightness as 0-1 fractions)
+  /// to an `[r, g, b]` triple of 0-255 integers.
+  static List<int> _hslToRgb(double h, double s, double l) {
+    if (s == 0) {
+      final gray = (l * 255).round();
+      return [gray, gray, gray];
+    }
+
+    double hueToRgb(double p, double q, double t) {
+      var tt = t;
+      if (tt < 0) tt += 1;
+      if (tt > 1) tt -= 1;
+      if (tt < 1 / 6) return p + (q - p) * 6 * tt;
+      if (tt < 1 / 2) return q;
+      if (tt < 2 / 3) return p + (q - p) * (2 / 3 - tt) * 6;
+      return p;
+    }
+
+    final q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+    final p = 2 * l - q;
+    final hNorm = (h % 360) / 360;
+
+    return [
+      (hueToRgb(p, q, hNorm + 1 / 3) * 255).round(),
+      (hueToRgb(p, q, hNorm) * 255).round(),
+      (hueToRgb(p, q, hNorm - 1 / 3) * 255).round(),
+    ];
   }
 
   /// Parse CSS border property value.

--- a/packages/docx_creator/lib/src/parsers/html/parser_context.dart
+++ b/packages/docx_creator/lib/src/parsers/html/parser_context.dart
@@ -22,19 +22,30 @@ class HtmlParserContext {
   }
 
   /// Parse CSS classes from <style> tags in the document.
+  ///
+  /// Handles grouped selectors (`.foo, .bar { ... }`) by mapping every
+  /// class named in the group to the shared declaration body, not just
+  /// the first one.
   static Map<String, String> _parseCssClasses(dom.Document document) {
     final cssMap = <String, String>{};
     final styles = document.querySelectorAll('style');
     for (var style in styles) {
       final text = style.text;
-      // Simple regex for .className { ... }
-      final matches =
-          RegExp(r'\.([a-zA-Z0-9_-]+)\s*\{([^}]+)\}').allMatches(text);
-      for (var match in matches) {
-        final className = match.group(1);
-        final styleBody = match.group(2);
-        if (className != null && styleBody != null) {
-          cssMap[className] = styleBody.trim();
+      // Match "<selector-list> { <body> }" rules, then split the selector
+      // list on commas so every class in a group gets the same body.
+      final rules = RegExp(r'([^{}]+)\{([^}]+)\}').allMatches(text);
+      for (var rule in rules) {
+        final selectorList = rule.group(1);
+        final styleBody = rule.group(2)?.trim();
+        if (selectorList == null || styleBody == null) continue;
+
+        for (var selector in selectorList.split(',')) {
+          final classMatch =
+              RegExp(r'^\.([a-zA-Z0-9_-]+)$').firstMatch(selector.trim());
+          final className = classMatch?.group(1);
+          if (className != null) {
+            cssMap[className] = styleBody;
+          }
         }
       }
     }

--- a/packages/docx_creator/lib/src/parsers/html/style_context.dart
+++ b/packages/docx_creator/lib/src/parsers/html/style_context.dart
@@ -1,4 +1,5 @@
 import '../../core/enums.dart';
+import 'color_utils.dart';
 
 /// Style context for inline text formatting inheritance.
 ///
@@ -148,25 +149,39 @@ class HtmlStyleContext {
       }
     }
 
-    // Style attribute based updates
+    // Style attribute based updates. Property lookups below are all
+    // case-insensitive with flexible whitespace around ':' so minified or
+    // uppercase CSS (e.g. "FONT-WEIGHT:BOLD") is recognized, not just the
+    // exact lowercase "property: value" form.
     if (style.isNotEmpty) {
-      if (style.contains('font-weight') &&
-          (style.contains('bold') || style.contains('700'))) {
-        ctx = ctx.copyWith(fontWeight: DocxFontWeight.bold);
+      final fontWeightMatch =
+          RegExp(r'font-weight\s*:\s*([a-z0-9]+)', caseSensitive: false)
+              .firstMatch(style);
+      if (fontWeightMatch != null) {
+        final value = fontWeightMatch.group(1)!.toLowerCase();
+        final numericWeight = int.tryParse(value);
+        // Word (and browsers) render 600+ as visually bold.
+        final isBold = value == 'bold' || (numericWeight != null && numericWeight >= 600);
+        if (isBold) ctx = ctx.copyWith(fontWeight: DocxFontWeight.bold);
       }
 
-      if (style.contains('font-style') && style.contains('italic')) {
+      if (RegExp(r'font-style\s*:\s*italic', caseSensitive: false)
+          .hasMatch(style)) {
         ctx = ctx.copyWith(fontStyle: DocxFontStyle.italic);
       }
 
-      if (style.contains('text-decoration') && style.contains('underline')) {
+      if (RegExp(r'text-decoration\s*:\s*[a-z\s]*underline',
+              caseSensitive: false)
+          .hasMatch(style)) {
         if (!ctx.decorations.contains(DocxTextDecoration.underline)) {
           ctx = ctx.copyWith(
               decorations: [...ctx.decorations, DocxTextDecoration.underline]);
         }
       }
 
-      if (style.contains('text-decoration') && style.contains('line-through')) {
+      if (RegExp(r'text-decoration\s*:\s*[a-z\s]*line-through',
+              caseSensitive: false)
+          .hasMatch(style)) {
         if (!ctx.decorations.contains(DocxTextDecoration.strikethrough)) {
           ctx = ctx.copyWith(decorations: [
             ...ctx.decorations,
@@ -175,15 +190,19 @@ class HtmlStyleContext {
         }
       }
 
-      final sizeMatch = RegExp(r"font-size:\s*(\d+)").firstMatch(style);
+      final sizeMatch =
+          RegExp(r'font-size\s*:\s*([\d.]+\s*(?:px|pt|em|rem|%)?)',
+                  caseSensitive: false)
+              .firstMatch(style);
       if (sizeMatch != null) {
-        final fs = double.tryParse(sizeMatch.group(1)!);
+        final fs = ColorUtils.parseCssLengthToPoints(sizeMatch.group(1)!);
         if (fs != null) ctx = ctx.copyWith(fontSize: fs);
       }
 
       // Color parsing
       final colorMatch = RegExp(
-              r"(?<!-)color:\s*['\x22]?(#[A-Fa-f0-9]{3,6}|rgb\([0-9,\s]+\)|rgba\([0-9.,\s]+\)|[a-zA-Z]+)['\x22]?")
+              r"(?<![-a-zA-Z])color:\s*['\x22]?(#[A-Fa-f0-9]{3,6}|rgba?\([0-9.,\s]+\)|hsla?\([0-9.,%\s]+\)|[a-zA-Z]+)['\x22]?",
+              caseSensitive: false)
           .firstMatch(style);
       if (colorMatch != null) {
         final val = colorMatch.group(1);
@@ -195,7 +214,8 @@ class HtmlStyleContext {
 
       // Background Color (Shading)
       final bgMatch = RegExp(
-              r"background-color:\s*['\x22]?(#[A-Fa-f0-9]{3,6}|rgb\([0-9,\s]+\)|rgba\([0-9.,\s]+\)|[a-zA-Z]+)['\x22]?")
+              r"background-color:\s*['\x22]?(#[A-Fa-f0-9]{3,6}|rgba?\([0-9.,\s]+\)|hsla?\([0-9.,%\s]+\)|[a-zA-Z]+)['\x22]?",
+              caseSensitive: false)
           .firstMatch(style);
       if (bgMatch != null) {
         final bgVal = bgMatch.group(1)?.toLowerCase();
@@ -237,7 +257,7 @@ class HtmlStyleContext {
   }
 }
 
-/// Parsed block-level styles (alignment, borders, shading).
+/// Parsed block-level styles (alignment, borders, shading, indentation).
 class HtmlBlockStyles {
   final String? shadingFill;
   final String? colorHex;
@@ -247,6 +267,15 @@ class HtmlBlockStyles {
   final DocxBorderSide? borderLeft;
   final DocxBorderSide? borderRight;
 
+  /// Left indentation in twips, from CSS `margin-left`/`padding-left`.
+  final int? indentLeft;
+
+  /// Right indentation in twips, from CSS `margin-right`/`padding-right`.
+  final int? indentRight;
+
+  /// First-line indentation in twips, from CSS `text-indent`.
+  final int? indentFirstLine;
+
   HtmlBlockStyles({
     this.shadingFill,
     this.colorHex,
@@ -255,5 +284,8 @@ class HtmlBlockStyles {
     this.borderBottom,
     this.borderLeft,
     this.borderRight,
+    this.indentLeft,
+    this.indentRight,
+    this.indentFirstLine,
   });
 }

--- a/packages/docx_creator/lib/src/parsers/html/table_parser.dart
+++ b/packages/docx_creator/lib/src/parsers/html/table_parser.dart
@@ -118,7 +118,23 @@ class HtmlTableParser {
           ColorUtils.parseCssBorderProperty(style, 'border'),
       borderRight: ColorUtils.parseCssBorderProperty(style, 'border-right') ??
           ColorUtils.parseCssBorderProperty(style, 'border'),
+      marginLeft: _lengthPropertyTwips(style, 'padding-left') ??
+          _lengthPropertyTwips(style, 'margin-left'),
+      marginRight: _lengthPropertyTwips(style, 'padding-right') ??
+          _lengthPropertyTwips(style, 'margin-right'),
     );
+  }
+
+  /// Reads a CSS length property (e.g. `padding-left: 10px`) and converts
+  /// it to twips (1/20th of a point), or null if not present.
+  int? _lengthPropertyTwips(String style, String property) {
+    final match = RegExp(
+      '$property\\s*:\\s*(-?[\\d.]+\\s*(?:px|pt|em|rem|%)?)',
+      caseSensitive: false,
+    ).firstMatch(style);
+    if (match == null) return null;
+    final points = ColorUtils.parseCssLengthToPoints(match.group(1)!);
+    return points != null ? (points * 20).round() : null;
   }
 
   Future<List<DocxBlock>> _parseCellContent(List<dom.Node> nodes,

--- a/packages/docx_creator/test/html_css_value_parsing_test.dart
+++ b/packages/docx_creator/test/html_css_value_parsing_test.dart
@@ -1,0 +1,86 @@
+import 'package:docx_creator/docx_creator.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('HTML CSS value/unit parsing', () {
+    test('converts font-size px to points', () async {
+      final nodes =
+          await DocxParser.fromHtml('<p><span style="font-size: 16px;">x</span></p>');
+      final para = nodes.single as DocxParagraph;
+      final text = para.children.single as DocxText;
+      expect(text.fontSize, 12); // 16px * 0.75 = 12pt
+    });
+
+    test('converts font-size em to points using the default base size',
+        () async {
+      final nodes = await DocxParser.fromHtml(
+          '<p><span style="font-size: 1.5em;">x</span></p>');
+      final para = nodes.single as DocxParagraph;
+      final text = para.children.single as DocxText;
+      expect(text.fontSize, 18); // 1.5 * 12pt base
+    });
+
+    test('recognizes uppercase/minified style declarations', () async {
+      final nodes = await DocxParser.fromHtml(
+          '<p><span style="FONT-WEIGHT:BOLD;text-align:center">x</span></p>');
+      final para = nodes.single as DocxParagraph;
+      final text = para.children.single as DocxText;
+      expect(text.fontWeight, DocxFontWeight.bold);
+    });
+
+    test('treats numeric font-weight 600+ as bold', () async {
+      final nodes = await DocxParser.fromHtml(
+          '<p><span style="font-weight: 800;">x</span></p>');
+      final para = nodes.single as DocxParagraph;
+      final text = para.children.single as DocxText;
+      expect(text.fontWeight, DocxFontWeight.bold);
+    });
+
+    test('does not treat font-weight below 600 as bold', () async {
+      final nodes = await DocxParser.fromHtml(
+          '<p><span style="font-weight: 400;">x</span></p>');
+      final para = nodes.single as DocxParagraph;
+      final text = para.children.single as DocxText;
+      expect(text.fontWeight, DocxFontWeight.normal);
+    });
+
+    test('parses hsl() colors', () async {
+      final nodes = await DocxParser.fromHtml(
+          '<p><span style="color: hsl(0, 100%, 50%);">x</span></p>');
+      final para = nodes.single as DocxParagraph;
+      final text = para.children.single as DocxText;
+      expect(text.color?.hex, 'FF0000');
+    });
+
+    test('applies a class-based text-align even in uppercase form',
+        () async {
+      final html = '<p style="TEXT-ALIGN: CENTER;">x</p>';
+      final nodes = await DocxParser.fromHtml(html);
+      final para = nodes.single as DocxParagraph;
+      expect(para.align, DocxAlign.center);
+    });
+
+    test('applies margin-left/text-indent as paragraph indentation',
+        () async {
+      final html =
+          '<p style="margin-left: 40px; text-indent: 20px;">Indented</p>';
+      final nodes = await DocxParser.fromHtml(html);
+      final para = nodes.single as DocxParagraph;
+      expect(para.indentLeft, 600); // 40px * 0.75pt/px * 20twips/pt
+      expect(para.indentFirstLine, 300);
+    });
+
+    test('maps every class in a grouped selector to the same style',
+        () async {
+      final html = '''
+<html><head><style>.foo, .bar { color: #FF0000; }</style></head>
+<body><p class="foo">A</p><p class="bar">B</p></body></html>
+''';
+      final nodes = await DocxParser.fromHtml(html);
+      final a = (nodes[0] as DocxParagraph).children.single as DocxText;
+      final b = (nodes[1] as DocxParagraph).children.single as DocxText;
+      expect(a.color?.hex, 'FF0000');
+      expect(b.color?.hex, 'FF0000');
+    });
+  });
+}


### PR DESCRIPTION
Closes #102.

## Summary
- Added `ColorUtils.parseCssLengthToPoints` (px/pt/em/rem/%  -> points) and use it for `font-size`, and for new `margin`/`padding`/`text-indent` handling.
- Style keyword matching (`font-weight`, `font-style`, `text-decoration`, `text-align`) is now case-insensitive and whitespace-tolerant via regex, instead of exact-lowercase `.contains()` checks.
- `font-weight: 600`-`900` is now treated as bold, not just literal `bold`/`700`.
- `hsl()`/`hsla()` colors are now converted to hex.
- Grouped selectors (`.foo, .bar { ... }`) now apply to every class in the group, not just whichever the old regex happened to match first.
- `margin-left`/`margin-right`/`padding-left`/`padding-right` on paragraphs now map to `DocxParagraph.indentLeft`/`indentRight`, `text-indent` to `indentFirstLine`; the same for table cells via `DocxTableCell.marginLeft`/`marginRight` — all three properties were previously read nowhere despite the AST/export side already supporting them.

## Test plan
- [x] `dart analyze` clean
- [x] New `test/html_css_value_parsing_test.dart` (9 tests) covering px/em conversion, case-insensitive matching, numeric font-weight threshold, hsl(), grouped selectors, and margin/text-indent
- [x] Full existing suite green (341 passing, 1 pre-existing skip), no regressions