### PR TITLE
fix(docx_creator): HTML/Markdown list and table parsing gaps

### DIFF
--- a/packages/docx_creator/lib/src/parsers/html/block_parser.dart
+++ b/packages/docx_creator/lib/src/parsers/html/block_parser.dart
@@ -158,6 +158,9 @@ class HtmlBlockParser {
         final table = await _tableParser.parseTable(element);
         return [table];
 
+      case 'dl':
+        return _parseDefinitionList(element, blockContext);
+
       case 'img':
         final img = await _imageParser.parseBlockImage(element);
         return img != null ? [img] : [];
@@ -198,6 +201,37 @@ class HtmlBlockParser {
           )
         ];
     }
+  }
+
+  /// Parses a definition list (`<dl>`) into one paragraph per `<dt>`/`<dd>`
+  /// (bold term, indented definition), since docx_creator has no dedicated
+  /// definition-list AST node. Previously `<dt>`/`<dd>` fell through to
+  /// plain inline pass-through with no separator, garbling
+  /// "<dt>Term</dt><dd>Definition</dd>" into a single "TermDefinition" run.
+  Future<List<DocxNode>> _parseDefinitionList(
+      dom.Element element, HtmlStyleContext context) async {
+    final paragraphs = <DocxNode>[];
+    for (var child in element.children) {
+      final tag = child.localName?.toLowerCase();
+      if (tag != 'dt' && tag != 'dd') continue;
+
+      final inlines =
+          await _inlineParser.parseInlines(child.nodes, context: context);
+      if (inlines.isEmpty) continue;
+
+      if (tag == 'dt') {
+        paragraphs.add(DocxParagraph(
+          children: inlines
+              .map((i) => i is DocxText
+                  ? i.copyWith(fontWeight: DocxFontWeight.bold)
+                  : i)
+              .toList(),
+        ));
+      } else {
+        paragraphs.add(DocxParagraph(children: inlines, indentLeft: 360));
+      }
+    }
+    return paragraphs;
   }
 
   DocxParagraph _parseCodeBlock(dom.Element element, DocxAlign align) {
@@ -270,6 +304,7 @@ class HtmlBlockParser {
       'table',
       'ul',
       'ol',
+      'dl',
       'blockquote',
       'pre',
       'hr',

--- a/packages/docx_creator/lib/src/parsers/html/list_parser.dart
+++ b/packages/docx_creator/lib/src/parsers/html/list_parser.dart
@@ -28,6 +28,20 @@ class HtmlListParser {
     final currentLevel = (styleContext != null && styleContext.listLevel >= 0)
         ? styleContext.listLevel
         : level;
+    final startIndex =
+        int.tryParse(element.attributes['start'] ?? '') ?? 1;
+
+    // A nested sublist's own bullet/numbered style so it can be applied as
+    // a per-item override once flattened below (DocxListItem has no way to
+    // carry a nested DocxList directly - list items only hold inline
+    // content - so the nested list's items are flattened into this one,
+    // stamped with an override so at least their indentation/bullet glyph
+    // still reflects their own type. See docx_creator/CLAUDE.md-style note:
+    // full per-item numbering-format switching within a single numId would
+    // require the abstract numbering definition to vary by level, which
+    // this exporter doesn't currently support.
+    DocxListStyle nestedOverrideStyle(bool nestedOrdered) =>
+        nestedOrdered ? DocxListStyle.decimal : DocxListStyle.disc;
 
     for (var child in element.children) {
       if (child.localName == 'li') {
@@ -39,7 +53,12 @@ class HtmlListParser {
             if (result is DocxParagraph) {
               items.add(DocxListItem(result.children, level: currentLevel));
             } else if (result is DocxList) {
-              items.addAll(result.items);
+              for (var nestedItem in result.items) {
+                items.add(nestedItem.copyWith(
+                  overrideStyle: nestedItem.overrideStyle ??
+                      nestedOverrideStyle(result.isOrdered),
+                ));
+              }
             }
           }
           continue;
@@ -75,13 +94,19 @@ class HtmlListParser {
           items.add(DocxListItem(inlines, level: currentLevel));
         }
 
-        // Flatten nested items into this list
+        // Flatten nested items into this list, stamped with an override
+        // reflecting the nested list's own type (see note above).
         for (var nested in nestedLists) {
-          items.addAll(nested.items);
+          for (var nestedItem in nested.items) {
+            items.add(nestedItem.copyWith(
+              overrideStyle: nestedItem.overrideStyle ??
+                  nestedOverrideStyle(nested.isOrdered),
+            ));
+          }
         }
       }
     }
 
-    return DocxList(items: items, isOrdered: ordered);
+    return DocxList(items: items, isOrdered: ordered, startIndex: startIndex);
   }
 }

--- a/packages/docx_creator/lib/src/parsers/markdown_parser.dart
+++ b/packages/docx_creator/lib/src/parsers/markdown_parser.dart
@@ -222,43 +222,56 @@ class MarkdownParser {
     int level = 0,
   }) async {
     final items = <DocxListItem>[];
+    final startIndex = int.tryParse(element.attributes['start'] ?? '') ?? 1;
 
     for (var child in element.children ?? []) {
       if (child is md.Element && child.tag == 'li') {
-        final currentInlines = <DocxInline>[];
+        // A "loose" list item can contain more than one <p> (a blank line
+        // between them in the source Markdown); those all belong to one
+        // logical item and must share a single bullet/number, not one each.
+        final itemInlines = <DocxInline>[];
 
-        void flushInlines() {
-          if (currentInlines.isNotEmpty) {
-            items.add(DocxListItem(List.from(currentInlines), level: level));
-            currentInlines.clear();
+        void flushItem() {
+          if (itemInlines.isNotEmpty) {
+            items.add(DocxListItem(List.of(itemInlines), level: level));
+            itemInlines.clear();
           }
         }
 
         // Process children of LI
         for (var node in child.children ?? []) {
           if (node is md.Element && (node.tag == 'ul' || node.tag == 'ol')) {
-            flushInlines();
-            // Found nested list
-            final nested = await _parseList(node,
-                ordered: node.tag == 'ol', level: level + 1);
-            items.addAll(nested.items);
-          } else if (node is md.Element && node.tag == 'p') {
-            flushInlines();
-            // Explicit paragraph in list item
-            final inlines = await _parseInlines(node.children ?? []);
-            if (inlines.isNotEmpty) {
-              items.add(DocxListItem(inlines, level: level));
+            flushItem();
+            // Found nested list. DocxListItem can only hold inline content
+            // (not a nested DocxList), so its items are flattened into this
+            // list; stamping an override style at least preserves the
+            // nested list's own bullet/numbered glyph and indentation.
+            final nestedOrdered = node.tag == 'ol';
+            final nested =
+                await _parseList(node, ordered: nestedOrdered, level: level + 1);
+            for (var nestedItem in nested.items) {
+              items.add(nestedItem.copyWith(
+                overrideStyle: nestedItem.overrideStyle ??
+                    (nestedOrdered
+                        ? DocxListStyle.decimal
+                        : DocxListStyle.disc),
+              ));
             }
+          } else if (node is md.Element && node.tag == 'p') {
+            // Explicit paragraph in list item - append to the same item
+            // rather than starting a new one.
+            if (itemInlines.isNotEmpty) itemInlines.add(DocxLineBreak());
+            itemInlines.addAll(await _parseInlines(node.children ?? []));
           } else {
             // Regular inline content
-            currentInlines.addAll(await _parseInline(node));
+            itemInlines.addAll(await _parseInline(node));
           }
         }
-        flushInlines();
+        flushItem();
       }
     }
 
-    return DocxList(items: items, isOrdered: ordered);
+    return DocxList(items: items, isOrdered: ordered, startIndex: startIndex);
   }
 
   static Future<DocxTable> _parseTable(md.Element element) async {
@@ -304,6 +317,7 @@ class MarkdownParser {
             children: [
               DocxParagraph(
                 children: inlines,
+                align: _cellAlign(child.attributes['align']),
               )
             ],
           ),
@@ -311,7 +325,20 @@ class MarkdownParser {
       }
     }
 
-    return DocxTableRow(cells: cells);
+    return DocxTableRow(cells: cells, isHeader: isHeader);
+  }
+
+  /// Maps a GFM table cell's `align` attribute (derived from the
+  /// `:---`/`:---:`/`---:` delimiter row) to [DocxAlign].
+  static DocxAlign _cellAlign(String? align) {
+    switch (align) {
+      case 'center':
+        return DocxAlign.center;
+      case 'right':
+        return DocxAlign.right;
+      default:
+        return DocxAlign.left;
+    }
   }
 
   static Future<String> _extractText(md.Node node) async {

--- a/packages/docx_creator/test/html_markdown_list_table_test.dart
+++ b/packages/docx_creator/test/html_markdown_list_table_test.dart
@@ -1,0 +1,102 @@
+import 'package:docx_creator/docx_creator.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('HTML list/dl parsing', () {
+    test('preserves nested list start index', () async {
+      final nodes =
+          await DocxParser.fromHtml('<ol start="5"><li>Five</li><li>Six</li></ol>');
+      final list = nodes.single as DocxList;
+      expect(list.startIndex, 5);
+    });
+
+    test('stamps a nested sublist with an override style for its own type',
+        () async {
+      final html = '<ol><li>A<ul><li>B</li></ul></li></ol>';
+      final nodes = await DocxParser.fromHtml(html);
+      final list = nodes.single as DocxList;
+
+      expect(list.items.length, 2);
+      expect(list.items[0].level, 0);
+      expect(list.items[1].level, 1);
+      expect(list.items[1].overrideStyle?.bullet, DocxListStyle.disc.bullet);
+    });
+
+    test('renders <dl>/<dt>/<dd> as separate paragraphs, not garbled text',
+        () async {
+      final html = '<dl><dt>Term</dt><dd>Definition</dd></dl>';
+      final nodes = await DocxParser.fromHtml(html);
+
+      expect(nodes.length, 2);
+      final dt = (nodes[0] as DocxParagraph).children.single as DocxText;
+      final dd = (nodes[1] as DocxParagraph).children.single as DocxText;
+      expect(dt.content, 'Term');
+      expect(dt.fontWeight, DocxFontWeight.bold);
+      expect(dd.content, 'Definition');
+    });
+  });
+
+  group('Markdown table alignment', () {
+    test('applies column alignment from the delimiter row', () async {
+      final md = '''
+| Left | Center | Right |
+|:-----|:------:|------:|
+| L    | C      | R     |
+''';
+      final nodes = await MarkdownParser.parse(md);
+      final table = nodes.single as DocxTable;
+      final dataRow = table.rows[1];
+
+      expect((dataRow.cells[0].children.single as DocxParagraph).align,
+          DocxAlign.left);
+      expect((dataRow.cells[1].children.single as DocxParagraph).align,
+          DocxAlign.center);
+      expect((dataRow.cells[2].children.single as DocxParagraph).align,
+          DocxAlign.right);
+    });
+
+    test('marks the header row as a header row', () async {
+      final md = '| H |\n|---|\n| v |\n';
+      final nodes = await MarkdownParser.parse(md);
+      final table = nodes.single as DocxTable;
+      expect(table.rows[0].isHeader, isTrue);
+      expect(table.rows[1].isHeader, isFalse);
+    });
+  });
+
+  group('Markdown list structure', () {
+    test('merges a loose multi-paragraph list item into one entry', () async {
+      final md = '1. First paragraph.\n\n   Second paragraph, same item.\n'
+          '2. Second item.\n';
+      final nodes = await MarkdownParser.parse(md);
+      final list = nodes.single as DocxList;
+
+      expect(list.items.length, 2);
+      final combined = list.items[0].children
+          .whereType<DocxText>()
+          .map((t) => t.content)
+          .join();
+      expect(combined, contains('First paragraph.'));
+      expect(combined, contains('Second paragraph, same item.'));
+    });
+
+    test('preserves an ordered list start number', () async {
+      final md = '5. Five\n6. Six\n';
+      final nodes = await MarkdownParser.parse(md);
+      final list = nodes.single as DocxList;
+      expect(list.startIndex, 5);
+    });
+
+    test('stamps a nested sublist with its own type override', () async {
+      final md = '- Level 1\n  1. Level 2\n  2. Level 2 item 2\n- Level 1 again\n';
+      final nodes = await MarkdownParser.parse(md);
+      final list = nodes.single as DocxList;
+
+      final nestedItems = list.items.where((i) => i.level == 1).toList();
+      expect(nestedItems, isNotEmpty);
+      for (final item in nestedItems) {
+        expect(item.overrideStyle?.numberFormat, DocxNumberFormat.decimal);
+      }
+    });
+  });
+}


### PR DESCRIPTION
Closes #103, #104, #105.

## Summary
**HTML parser:**
- `<ol start="n">` now sets `DocxList.startIndex`.
- Nested `<ul>`/`<ol>` items, when flattened into the parent list (required by the current AST - a `DocxListItem` can only hold inline content, not a nested `DocxList`), are now stamped with an `overrideStyle` reflecting their own type, so at least indentation/bullet glyph survives. Full per-item numbering-*format* switching within a single Word numbering definition is a deeper limitation of how `w:numFmt` is scoped in this exporter - noted, not fully solved here.
- `<dl>`/`<dt>`/`<dd>` now render as a bold-term paragraph + an indented definition paragraph instead of garbling into one run of concatenated text.

**Markdown parser:**
- Table column alignment (`:---`, `:---:`, `---:`) is now applied - previously parsed by `package:markdown` into each cell's `align` attribute but never read.
- Also found+fixed in the same function: computed row `isHeader` was never actually passed to `DocxTableRow`.
- Ordered list start numbers (`5. Five`) are now preserved.
- A loose list item with multiple paragraphs now stays one logical item instead of splitting into one bulleted/numbered entry per paragraph.
- Nested sublists get the same `overrideStyle` treatment as the HTML parser, for the same underlying reason.

## Test plan
- [x] `dart analyze` clean
- [x] New `test/html_markdown_list_table_test.dart` (8 tests)
- [x] Full existing suite green (340 passing, 1 pre-existing skip), no regressions